### PR TITLE
docs: CLAUDE.md + frontend design system + tech stack update

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# ── LLM ──────────────────────────────────────────────────────────────────────
+ANTHROPIC_API_KEY=sk-ant-...
+LLM_MODEL=claude-sonnet-4-6
+LLM_TEMPERATURE=0.1
+
+# ── Vector Store ──────────────────────────────────────────────────────────────
+VECTOR_STORE_TYPE=chroma          # chroma | qdrant
+CHROMA_PERSIST_DIR=./knowledge_base/vector_store
+
+# Qdrant (production)
+# QDRANT_URL=http://localhost:6333
+# QDRANT_COLLECTION=hydro_kb
+
+# ── Embedding ─────────────────────────────────────────────────────────────────
+EMBEDDING_MODEL=BAAI/bge-large-zh-v1.5
+
+# ── Reranker ──────────────────────────────────────────────────────────────────
+RERANKER_MODEL=BAAI/bge-reranker-v2-m3
+RERANKER_TOP_K=5
+
+# ── Knowledge Base ────────────────────────────────────────────────────────────
+KB_DOCS_DIR=./knowledge_base/docs_internal
+
+# ── API ───────────────────────────────────────────────────────────────────────
+API_HOST=0.0.0.0
+API_PORT=8000
+API_RELOAD=true
+
+# ── CORS ──────────────────────────────────────────────────────────────────────
+CORS_ORIGINS=http://localhost:5173,http://localhost:3000
+
+# ── LangSmith (optional tracing) ─────────────────────────────────────────────
+# LANGCHAIN_TRACING_V2=true
+# LANGCHAIN_API_KEY=ls__...
+# LANGCHAIN_PROJECT=hydro-om-copilot

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,282 @@
+# CLAUDE.md — Hydro O&M AI Copilot
+
+开发者（和 AI 工具）快速参考。阅读本文件后可独立在此代码库中完成任务。
+
+---
+
+## 项目概述
+
+水电机组异常诊断辅助系统。用户描述故障现象，AI 返回根因分析、SOP 检查清单和运维报告草稿。
+
+**定位**：辅助诊断，不替代工程师判断。当前版本聚焦三个故障域：振动/摆度、调速器油压、轴承温升。
+
+---
+
+## 技术栈
+
+| 层 | 技术 |
+|----|------|
+| 前端 | React 18 + Vite + TypeScript + Tailwind CSS v3 |
+| 状态 | Zustand |
+| 后端 | FastAPI + LangGraph + LangChain + Python 3.11 |
+| LLM | claude-sonnet-4-6 (temperature=0.1) |
+| 向量存储 | ChromaDB（dev） / Qdrant（prod） |
+| 嵌入 | BAAI/bge-large-zh-v1.5（本地，1024维）|
+| 重排序 | BAAI/bge-reranker-v2-m3 |
+| 包管理 | `uv`（后端）/ `npm`（前端）|
+
+---
+
+## 目录结构
+
+```
+hydro-om-copilot/
+├── backend/
+│   ├── app/
+│   │   ├── agents/         # LangGraph 节点：graph.py, state.py, symptom_parser.py …
+│   │   ├── api/routes/     # FastAPI 路由：diagnosis.py, health.py
+│   │   ├── models/         # Pydantic 模型：request.py, response.py
+│   │   ├── rag/            # 检索：hybrid_retriever.py, bm25_index.py, chunker.py …
+│   │   ├── utils/          # prompts.py（所有 LLM 提示词）, streaming.py
+│   │   ├── config.py       # Pydantic Settings（读 .env）
+│   │   └── main.py         # FastAPI 入口，lifespan 挂载 retriever
+│   ├── tests/
+│   └── pyproject.toml
+├── frontend/
+│   ├── src/
+│   │   ├── components/diagnosis/   # InputPanel, StreamingOutput, RootCauseCard …
+│   │   ├── hooks/                  # useSSEDiagnosis.ts, useSessionHistory.ts
+│   │   ├── pages/                  # DiagnosisPage.tsx, HistoryPage.tsx
+│   │   ├── services/               # diagnosisApi.ts（SSE 客户端）
+│   │   ├── store/                  # diagnosisStore.ts（Zustand）
+│   │   └── types/                  # diagnosis.ts（TypedDict 镜像）
+│   ├── eslint.config.js
+│   ├── tailwind.config.ts
+│   └── tsconfig.json
+├── scripts/
+│   ├── ingest_kb.py        # 知识库入库脚本
+│   └── validate_kb.py      # YAML 元数据校验
+├── docs/                   # 架构文档
+├── docker-compose.yml
+└── .env.example
+```
+
+---
+
+## 开发命令
+
+### 后端
+
+```bash
+cd backend
+uv sync --extra dev        # 安装依赖（含 dev：ruff, pytest, mypy）
+cp ../.env.example ../.env # 首次设置环境变量
+uv run uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+### 前端
+
+```bash
+cd frontend
+npm install
+npm run dev                # Vite dev server → localhost:5173
+npm run build              # 生产构建（tsc + vite build）
+npm run type-check         # 仅类型检查，不输出文件
+npm run lint               # ESLint
+```
+
+### 知识库入库
+
+```bash
+cd backend
+uv run python ../scripts/validate_kb.py   # 先校验 YAML 元数据
+uv run python ../scripts/ingest_kb.py     # 入库（ChromaDB + BM25）
+uv run python ../scripts/ingest_kb.py --reset  # 清空后重建
+```
+
+### Docker（全栈）
+
+```bash
+docker-compose up --build
+# backend:  localhost:8000
+# frontend: localhost:5173
+# qdrant:   localhost:6333
+```
+
+---
+
+## Lint 命令
+
+```bash
+# 前端
+cd frontend && npm run lint
+
+# 后端（从项目根目录）
+uv tool run ruff check backend/
+uv tool run ruff check --fix backend/   # 自动修复
+```
+
+---
+
+## 架构约束（不可修改文件）
+
+以下文件受架构保护，**不得修改**：
+
+| 文件 | 原因 |
+|------|------|
+| `frontend/src/store/diagnosisStore.ts` | 定义全局状态契约；`riskLevelColor` 导出浅色主题类，组件需本地定义深色版本 |
+| `frontend/src/hooks/useSSEDiagnosis.ts` | SSE 生命周期管理，修改有副作用风险 |
+| `frontend/src/hooks/useSessionHistory.ts` | localStorage 持久化逻辑 |
+| `frontend/src/services/diagnosisApi.ts` | SSE 解析客户端 |
+| `frontend/src/types/diagnosis.ts` | TypeScript 类型定义，镜像后端 Pydantic 模型 |
+
+### `DiagnosisRequest` 类型
+
+```typescript
+interface DiagnosisRequest {
+  session_id?: string;
+  unit_id?: string;   // 纯字符串，如 "#1机"，不是数字 ID
+  query: string;
+  image_base64?: string;
+}
+```
+
+### `riskLevelColor` 不可直接用于深色主题
+
+`diagnosisStore.ts` 导出的 `riskLevelColor` 是浅色 Tailwind 类（`text-green-700 bg-green-100` 等）。
+深色主题组件（`RiskBadge`, `HistoryPage`）必须本地定义：
+
+```typescript
+const darkRiskColors: Record<RiskLevel, string> = {
+  low: "text-emerald-400 bg-emerald-950 border-emerald-800",
+  medium: "text-amber bg-amber-950 border-amber-800",
+  high: "text-orange-400 bg-orange-950 border-orange-800",
+  critical: "text-red-400 bg-red-950 border-red-800 critical-pulse",
+};
+```
+
+---
+
+## Agent 流程
+
+```
+symptom_parser → [image_agent?] → retrieval → reasoning → report_gen
+```
+
+- `image_agent` 仅在 `state.image_base64` 非空时执行（条件边）
+- `retrieval` 并行查询三个语料库（procedure / rule / case）
+- 所有节点返回 partial state，不做全量覆盖
+- 节点入口文件：`backend/app/agents/graph.py`
+
+### 语料库 → 集合映射
+
+| 语料库 | 匹配 doc_id 前缀 |
+|--------|-----------------|
+| `procedure` | `L2.TOPIC.*` + `L1.*` |
+| `rule` | `L2.SUPPORT.RULE.001` |
+| `case` | `L2.SUPPORT.CASE.001` |
+
+---
+
+## 前端设计系统要点
+
+详见 `docs/06-frontend-design-system.md`，摘要：
+
+- **主题**：暗色工业 HMI（`#0a0f1a` 背景，`#f59e0b` 琥珀色 accent）
+- **字体**：`font-display`=Rajdhani，`font-sans`=Noto Sans SC，`font-mono`=JetBrains Mono
+- **布局**：双列（`5/12` 左侧输入 + `7/12` 右侧结果），高度 `calc(100vh-52px)`
+- **动画**：`.scan-line`（流式输出），`.node-active`（当前节点），`.animate-result`（结果模块出现）
+
+---
+
+## 环境变量（`.env`）
+
+关键变量（完整列表见 `.env.example`）：
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+LLM_MODEL=claude-sonnet-4-6
+LLM_TEMPERATURE=0.1
+
+VECTOR_STORE_TYPE=chroma            # chroma | qdrant
+CHROMA_PERSIST_DIR=./knowledge_base/vector_store
+
+EMBEDDING_MODEL=BAAI/bge-large-zh-v1.5
+RERANKER_MODEL=BAAI/bge-reranker-v2-m3
+
+KB_DOCS_DIR=./knowledge_base/docs_internal
+CORS_ORIGINS=http://localhost:5173
+
+# 可选：LangSmith 追踪
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_API_KEY=ls__...
+```
+
+---
+
+## 知识库结构
+
+四层体系（L0–L3），YAML frontmatter 元数据：
+
+```yaml
+---
+doc_id: L2.TOPIC.VIB.001
+doc_level: L2
+route_keys: [vibration_swing]
+upstream: [L1.001]
+downstream: [L3.VIB.001.P01]
+title: 振动摆度诊断导图
+---
+```
+
+`doc_id` 前缀用于前端知识库来源颜色编码：
+- `L1.*` → 蓝色
+- `L2.TOPIC.*` → 琥珀色
+- `L2.SUPPORT.RULE.*` → 红色
+- `L2.SUPPORT.CASE.*` → 绿色
+
+---
+
+## 代码规范
+
+### TypeScript
+- 严格模式（`"strict": true`）
+- 导入路径别名：`@/` → `src/`
+- `tsconfig.json` 包含 `"types": ["vite/client"]`（`import.meta.env` 支持）
+
+### Python
+- 目标版本 Python 3.11
+- `Optional[X]` 写为 `X | None`（UP045，ruff 强制）
+- `Iterator` 从 `collections.abc` 导入（UP035，ruff 强制）
+- 不用 `str, Enum`，改用 `StrEnum`（UP042，ruff 强制）
+- Import 排序：标准库 → 第三方 → 本地（I001，ruff 强制）
+
+### 提交规范
+
+遵循 Conventional Commits：
+```
+feat:  新功能
+fix:   修复 bug
+docs:  文档更新
+refactor: 重构（无功能变化）
+chore: 构建、依赖、配置
+```
+
+---
+
+## 常见问题
+
+**Q: `npm run lint` 报 ESLint 找不到 config**
+A: 需要 `eslint.config.js`（flat config），已存在于 `frontend/`。若 node_modules 未安装，先 `npm install`。
+
+**Q: `uv run ruff` 报 ruff 找不到**
+A: 用 `uv tool run ruff`，或 `uv sync --extra dev` 后用 `.venv/bin/ruff`。
+
+**Q: 前端 `import.meta.env` TS 报错**
+A: `tsconfig.json` 需有 `"types": ["vite/client"]`，已配置。
+
+**Q: 风险徽章颜色在深色背景下不可见**
+A: 不要用 `diagnosisStore.riskLevelColor`，使用组件本地的 `darkRiskColors`。
+
+**Q: SSE 流式输出中途中断**
+A: 检查 `AbortController` 是否被意外触发；`useSSEDiagnosis.ts` 在每次 `run()` 前会调用 `abortRef.current?.abort()` 取消上一次请求。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./knowledge_base:/app/knowledge_base
+      - ./backend/app:/app/app
+    env_file:
+      - .env
+    environment:
+      - CHROMA_PERSIST_DIR=/app/knowledge_base/vector_store
+      - KB_DOCS_DIR=/app/knowledge_base/docs_internal
+    depends_on:
+      - qdrant
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend/src:/app/src
+    environment:
+      - VITE_API_BASE_URL=http://localhost:8000
+
+  qdrant:
+    image: qdrant/qdrant:latest
+    ports:
+      - "6333:6333"
+    volumes:
+      - qdrant_data:/qdrant/storage
+
+volumes:
+  qdrant_data:

--- a/docs/01-tech-stack.md
+++ b/docs/01-tech-stack.md
@@ -1,0 +1,259 @@
+# 技术选型逻辑、Scale-Up 可行性与 Trade-off
+
+## 1. 选型全景表
+
+| 层级 | 选型 | 备选方案 | 核心理由 |
+|------|------|----------|----------|
+| 前端框架 | React 18 | Vue 3, Svelte | 生态成熟，团队熟悉，LangChain.js 集成 |
+| 构建工具 | Vite | CRA, webpack | 原生 ESM HMR < 100ms，冷启动 10x 快于 CRA |
+| 类型系统 | TypeScript | JavaScript | Agent 输出结构复杂，强类型防止 SSE 解析错误 |
+| CSS 框架 | Tailwind CSS v3 | styled-components, MUI | v4 仍 beta，shadcn/ui 不支持；v3 生产稳定 |
+| 字体 | Rajdhani + Noto Sans SC + JetBrains Mono | Inter（已弃用） | 工业 HMI 视觉语言；中文可读性；等宽报告输出 |
+| 前端 Lint | ESLint v9 + typescript-eslint | tslint（已停维护） | 原生 TS 类型感知 lint，flat config（`eslint.config.js`）|
+| 状态管理 | Zustand | Redux, Jotai | 轻量级，SSE appendToken 场景下 selector 粒度精准 |
+| 后端框架 | FastAPI | Django, Flask | 原生 async，StreamingResponse 天然支持 SSE |
+| Agent 编排 | LangGraph | 手工 async 链, LangChain LCEL | StateGraph + 条件边 + 断点恢复，节点可单独测试 |
+| 包管理 | uv | pip, poetry | Rust 实现，安装速度约 10x，lock file 可重现 |
+| 后端 Lint | ruff | flake8 + isort + pyupgrade | 单工具覆盖格式化/排序/升级，速度快 10-100x |
+| LLM | claude-sonnet-4-6 | GPT-4o, Gemini 1.5 Pro | 中文推理、结构化 JSON 输出质量最优 |
+| 向量存储（dev） | ChromaDB | FAISS, Weaviate | 零配置本地运行，SQLite 持久化 |
+| 向量存储（prod） | Qdrant | Pinecone, Weaviate | 开源可自托管，混合检索，分布式扩展 |
+| 嵌入模型 | BAAI/bge-large-zh-v1.5 | text-embedding-3, m3e-base | 中文专业术语 embedding 质量最优，本地无 API 成本 |
+| 重排序 | BAAI/bge-reranker-v2-m3 | cross-encoder/ms-marco | 同家族模型，与 bge 嵌入协同效果好 |
+| 稀疏检索 | BM25 + jieba | ElasticSearch BM25 | 轻量，无需外部服务，与 RRF 融合简单 |
+| 可观测性 | LangSmith | OpenTelemetry + Jaeger | 原生 LangGraph 集成，prompt 链路可视化 |
+
+---
+
+## 2. 前端栈
+
+### 2.1 Vite 替代 CRA
+
+- **HMR**：Vite 利用原生 ESM，模块热更新延迟 < 100ms；CRA 基于 webpack bundle，大项目 HMR 可达 5-30s
+- **冷启动**：Vite 按需编译，首次启动仅编译入口模块；CRA 全量打包，冷启动随项目体积线性增长
+- **Bundle size**：Vite rollup 输出支持 code splitting + tree shaking，典型生产包比 CRA 小 30-40%
+
+### 2.2 TypeScript 的必要性
+
+Agent 输出结构复杂（`DiagnosisResult` 含嵌套 `RootCause[]`、`CheckStep[]`、`RiskLevel` 枚举），SSE 流式解析时任何字段拼写错误都会导致静默 `undefined`。TypeScript 在编译期捕获这类错误，避免运行时诊断结果渲染异常。
+
+关键类型文件：`frontend/src/types/diagnosis.ts`
+
+### 2.3 Tailwind v3 而非 v4
+
+- Tailwind v4 截至本项目搭建时仍为 beta，API 未稳定
+- shadcn/ui 组件库明确依赖 v3，v4 存在兼容性断裂
+- v3 的 JIT 编译模式已足够满足性能需求
+
+### 2.4 Zustand 而非 Redux
+
+| 维度 | Zustand | Redux Toolkit |
+|------|---------|---------------|
+| 包体积 | ~2KB | ~20KB |
+| 样板代码 | 最小（create + set） | action/reducer/selector 三层 |
+| SSE 实时更新 | `appendToken` 直接 `set(state => ...)` | 需要 dispatch action |
+| selector 粒度 | 函数式，按需订阅 | `useSelector` 同样精准但更冗长 |
+| DevTools | 支持（zustand/middleware） | 原生支持 |
+
+`appendToken` 在 SSE 高频更新（每 token 一次）场景下，Zustand 的函数式 `set` 不触发无关组件重渲染。
+
+---
+
+## 3. 后端栈
+
+### 3.1 FastAPI 与 SSE 的天然适配
+
+FastAPI 基于 Starlette 的 ASGI 异步模型，`StreamingResponse` 接受 `AsyncGenerator[str]`，与 LangGraph 的 `astream_events` 直接组合。每个连接占用一个协程而非线程，支持大量并发 SSE 连接。
+
+配置参数（`config.py`）：
+- `api_host: 0.0.0.0`
+- `api_port: 8000`
+- `api_reload: bool`（开发时热重载）
+
+### 3.2 LangGraph 相比手工 async 编排的优势
+
+| 维度 | 手工 async 链 | LangGraph StateGraph |
+|------|--------------|----------------------|
+| 节点隔离 | 函数调用，共享局部变量 | 每个节点输入/输出 partial state，边界清晰 |
+| 错误边界 | 需手工 try/except | 节点异常写入 `state.error`，不影响其他节点 |
+| 条件路由 | if/else 混在业务逻辑中 | `add_conditional_edges` 声明式定义 |
+| 可测试性 | 依赖整个调用链 | 每个节点函数可单独 mock state 测试 |
+| 断点恢复 | 不支持 | `interrupt_before` / `interrupt_after` |
+| 流式事件 | 需手工实现事件总线 | `astream_events` 原生支持 |
+
+### 3.3 uv 的 10x 安装速度
+
+uv 使用 Rust 实现，通过并行下载和增量缓存，典型 `uv sync` 耗时 < 5s（vs. `pip install -r requirements.txt` 的 60-120s）。在 CI/CD 中，每次构建节省约 1-2 分钟，对于需要频繁更新知识库依赖的场景尤为显著。
+
+---
+
+## 4. LLM：claude-sonnet-4-6
+
+### 4.1 与竞品比较
+
+| 维度 | claude-sonnet-4-6 | GPT-4o | Gemini 1.5 Pro |
+|------|-------------------|--------|----------------|
+| 中文专业术语推理 | 优秀 | 良好 | 良好 |
+| 结构化 JSON 输出稳定性 | 高（少幻构字段） | 中（偶有额外字段） | 中 |
+| 上下文窗口 | 200K tokens | 128K tokens | 1M tokens |
+| 成本（输入/MTok） | 中 | 中 | 低 |
+| 工具调用 / Function calling | 原生支持 | 原生支持 | 原生支持 |
+
+水电诊断场景对 JSON 输出结构稳定性要求极高（`root_causes[].probability` 等字段若幻构会导致 Pydantic 解析失败），claude-sonnet-4-6 在此维度表现最优。
+
+### 4.2 Temperature=0.1 的设计依据
+
+诊断场景需要**确定性推理**而非创造性输出。低 temperature 确保：
+- 相同症状输入 → 相同根因排序（可审计）
+- 结构化 JSON 字段名不产生随机变体
+- 概率值（`probability`）保持稳定，不因采样噪声跳变
+
+来源：`backend/app/config.py:16` - `llm_temperature: float = 0.1`
+
+### 4.3 Fallback 策略（P2 占位）
+
+通过 `config.py` 的 `llm_model` 字段配置化切换，无需修改业务代码：
+
+```
+llm_model = "claude-sonnet-4-6"   # 默认
+llm_model = "claude-haiku-4-5-20251001"  # 成本降级
+llm_model = "gpt-4o"              # 供应商故障切换（需替换 ChatAnthropic → ChatOpenAI）
+```
+
+---
+
+## 5. 向量存储迁移路径：ChromaDB → Qdrant
+
+### 5.1 ChromaDB 的局限性
+
+ChromaDB 使用 SQLite 作为持久化存储，`chroma_persist_dir = "./knowledge_base/vector_store"`：
+- 单文件 SQLite，无法多进程写入（dev 环境可接受）
+- 不支持分布式部署
+- 过滤能力有限（基于 metadata `where` 查询）
+- Collection 数量增大时（多电厂场景）性能下降
+
+### 5.2 Qdrant 的生产能力
+
+| 能力 | ChromaDB | Qdrant |
+|------|----------|--------|
+| 分布式 | 否 | 是（sharding + replication） |
+| 混合检索 | 否 | 原生 sparse + dense |
+| 过滤精度 | metadata WHERE | 强类型 payload filter |
+| gRPC 接口 | 否 | 是（低延迟） |
+| 快照/备份 | 否 | 是 |
+
+### 5.3 迁移方案
+
+切换仅需修改 `config.py`：
+```
+vector_store_type = "qdrant"
+qdrant_url = "http://qdrant-service:6333"
+```
+
+`backend/app/rag/vectorstore.py` 的 `build_vectorstore()` 根据 `vector_store_type` 分支初始化不同客户端，业务代码零改动。
+
+---
+
+## 6. Scale-Up 可行性分析
+
+### 6.1 水平扩展
+
+```
+负载均衡器 (Nginx / ALB)
+    ├── FastAPI Worker × N  (uvicorn workers 或 Kubernetes Pod)
+    ├── Qdrant Cluster       (3 节点，collection sharding)
+    └── CDN (CloudFront)     (前端静态资源)
+```
+
+FastAPI 无状态（`AgentState` 生命周期限于单次请求），可直接水平扩展。Session ID 由客户端生成（UUID4），无需 sticky session。
+
+### 6.2 多电厂支持：命名空间隔离
+
+Collection 命名规范：`plant_<plant_id>_<corpus>`
+
+例：
+- `plant_yantan_procedure`
+- `plant_yantan_rule`
+- `plant_longtan_procedure`
+
+隔离效果：
+- 查询时通过 `plant_id` 路由到对应 collection，防止跨厂站语料污染
+- 每个电厂可独立更新知识库，不影响其他电厂
+- BM25 index 文件：`bm25_<plant_id>_<corpus>.pkl`
+
+### 6.3 多模态扩展：HMI 截图 → 视频帧
+
+当前能力：单张 HMI 截图 → OCR 文本提取（`image_agent` 节点）
+
+路径预留：
+1. 视频帧：`image_agent` 接受 `frames: list[str]` 并行处理多帧，OCR 结果 concat
+2. 时序数据：`image_agent` 调用 Claude vision API 分析曲线趋势图
+3. 边界：不做实时摄像头流分析（单次诊断请求范式）
+
+### 6.4 多语言 LLM 支持
+
+通过 `config.py:llm_model` 运行时切换，prompts.py 中所有提示词保持中文（目标用户为中文运维人员）。若需多语言支持，prompts.py 按语言分目录即可。
+
+---
+
+## 7. Lint 工具链
+
+### 7.1 前端：ESLint v9 + typescript-eslint
+
+ESLint v9 迁移至 flat config（`eslint.config.js`），移除了 `.eslintrc.*` 格式。配置入口：
+
+```js
+// frontend/eslint.config.js
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  ...tseslint.configs.recommended,
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "@typescript-eslint/no-explicit-any": "warn",
+      "@typescript-eslint/no-unused-expressions": ["error", { allowShortCircuit: true }],
+    },
+  },
+  { ignores: ["dist/**", "node_modules/**"] },
+);
+```
+
+`allowShortCircuit: true` 用于兼容 `useSSEDiagnosis.ts` 中的 `condition && fn()` 短路调用模式（该文件不可修改）。
+
+执行：`npm run lint`（`cd frontend` 后）
+
+### 7.2 后端：ruff
+
+`pyproject.toml` 中配置：
+```toml
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP"]
+```
+
+规则集含义：
+- `E` — pycodestyle 格式错误
+- `F` — Pyflakes（未使用 import、未定义名称）
+- `I` — isort 排序
+- `UP` — pyupgrade（Python 3.11 语法升级，如 `Optional[X]` → `X | None`，`StrEnum`）
+
+执行：`uv tool run ruff check backend/`（项目根目录）
+自动修复：`uv tool run ruff check --fix backend/`
+
+---
+
+## 8. 已知 Trade-off 汇总
+
+| Trade-off | 当前选择 | 代价 | 触发升级条件 |
+|-----------|----------|------|--------------|
+| ChromaDB vs Qdrant | ChromaDB（dev） | 无法多进程写入 | 生产部署 / 多电厂 |
+| BM25 Pickle vs ES | Pickle 文件 | 无法增量更新，重建成本 O(n) | 文档量 > 10K / 在线更新需求 |
+| 双调用模式 | astream + ainvoke | LLM 调用额外触发一次 | P2 优化：在 astream_events 中捕获最终 state |
+| 关键词路由 vs LLM 分类 | 关键词打分 | 不覆盖新故障类型 | 故障类型 > 10 类 / 召回率 < 80% |
+| 本地嵌入 vs API 嵌入 | 本地 BGE | 首次加载 ~2GB 模型权重 | GPU 推理加速需求 / 云端部署 |
+| SSE vs WebSocket | SSE | 单向推送，无法客户端 → 服务端流 | 需要人机交互节点（human-in-the-loop） |

--- a/docs/02-langgraph-architecture.md
+++ b/docs/02-langgraph-architecture.md
@@ -1,0 +1,301 @@
+# LangGraph 状态机架构设计、业务约束与能力边界
+
+## 1. 设计动机：为什么用 StateGraph 而非直接调用链
+
+### 1.1 节点隔离与错误边界
+
+手工 async 调用链将所有逻辑串联在一个函数中，任何中间步骤的异常都会中断整条链路。LangGraph StateGraph 的每个节点是独立的 async 函数，输出写入 `AgentState` 的指定字段：
+
+- `symptom_parser` 失败 → `state.error` 写入错误信息，后续节点可检查并降级处理
+- `image_agent` 失败 → `state.ocr_text` 为 None，retrieval 节点仍可继续（仅使用文本查询）
+- 节点函数可单独 mock `AgentState` 进行单元测试，无需运行整条链
+
+### 1.2 每个节点输出 partial state
+
+节点函数只返回它修改的字段（`dict`），LangGraph 自动 merge 到全局 `AgentState`：
+
+```python
+# symptom_parser_node 只返回它负责的字段
+return {
+    "parsed_symptom": result,
+    "topic": topic,
+}
+# 不修改 raw_query、image_base64、retrieved 等其他字段
+```
+
+这种设计的好处：
+- 节点职责单一，易于理解和测试
+- 不同节点可并发执行（当无数据依赖时）
+- 状态演化可追踪（LangSmith 按节点记录 state diff）
+
+---
+
+## 2. AgentState 字段设计
+
+完整定义见：`backend/app/agents/state.py`
+
+### 2.1 字段生命周期
+
+| 字段 | 类型 | 生产节点 | 消费节点 | 说明 |
+|------|------|----------|----------|------|
+| `session_id` | `str` | API 层（UUID4） | — | 全生命周期不变 |
+| `raw_query` | `str` | API 层 | symptom_parser, retrieval, reasoning | 用户原始输入，不可修改 |
+| `image_base64` | `Optional[str]` | API 层 | route_after_parse, image_agent | base64 编码的截图 |
+| `parsed_symptom` | `Optional[ParsedSymptom]` | symptom_parser | reasoning, report_gen | LLM 结构化解析结果 |
+| `ocr_text` | `Optional[str]` | image_agent | retrieval, reasoning | HMI 截图 OCR 文本 |
+| `topic` | `Optional[str]` | symptom_parser | retrieval | 故障类型路由键 |
+| `retrieved` | `Optional[RetrievedContext]` | retrieval | reasoning | 三库检索结果 |
+| `root_causes` | `list[dict]` | reasoning | report_gen | Top-3 根因假设 |
+| `check_steps` | `list[dict]` | report_gen | API 层（输出） | 结构化检查步骤 |
+| `risk_level` | `str` | reasoning | report_gen, API 层 | low/medium/high/critical |
+| `escalation_required` | `bool` | reasoning | report_gen | 是否需要升级处理 |
+| `escalation_reason` | `Optional[str]` | reasoning | report_gen | 升级原因说明 |
+| `report_draft` | `Optional[str]` | report_gen | API 层（输出） | 班组交班汇报草稿 |
+| `stream_tokens` | `Annotated[list[str], add_messages]` | 各 LLM 节点 | SSE streaming | token 流累积 |
+| `sources` | `list[str]` | retrieval | API 层（输出） | 引用文档 doc_id 列表 |
+| `error` | `Optional[str]` | 任意节点 | API 层 | 错误信息，不中断流程 |
+
+### 2.2 `stream_tokens` 的 `add_messages` reducer 设计
+
+`stream_tokens` 使用 `Annotated[list[str], add_messages]` 注解。`add_messages` 是 LangGraph 内置的 reducer，语义是"追加"而非"覆盖"：
+
+```python
+# 当节点返回 {"stream_tokens": ["新 token"]} 时
+# LangGraph 调用 add_messages(current_list, ["新 token"])
+# 结果是追加，而非替换
+```
+
+这使得多个节点可以向 `stream_tokens` 追加内容，无需手工合并列表。SSE streaming 层（`streaming.py`）监听 `on_chat_model_stream` 事件直接推送 token，`stream_tokens` 主要用于 LangSmith trace 记录完整 token 序列。
+
+---
+
+## 3. 节点拓扑图与数据流
+
+### 3.1 完整流程图
+
+```
+用户请求 (raw_query + image_base64?)
+        │
+        ▼
+┌─────────────────┐
+│  symptom_parser  │  LLM JSON 解析 → parsed_symptom, topic
+└────────┬────────┘
+         │
+         ▼
+   route_after_parse
+    (条件边)
+    ┌────┴────┐
+    │         │
+    │ image?  │ no image
+    ▼         ▼
+┌──────────┐ ┌───────────┐
+│image_agent│ │           │
+│ (OCR)    │ │           │
+└────┬─────┘ │           │
+     │       │           │
+     └───────┼───────────┘
+             ▼
+     ┌───────────────┐
+     │   retrieval   │  3路并行检索（asyncio.gather）
+     │  ┌─────────┐  │  ├── procedure corpus
+     │  │ BM25 +  │  │  ├── rule corpus
+     │  │ Dense   │  │  └── case corpus
+     │  │ + RRF   │  │
+     │  └─────────┘  │
+     └───────┬───────┘
+             │
+             ▼
+     ┌───────────────┐
+     │   reasoning   │  LLM → root_causes, risk_level, escalation
+     └───────┬───────┘
+             │
+             ▼
+     ┌───────────────┐
+     │   report_gen  │  LLM → check_steps, report_draft
+     └───────┬───────┘
+             │
+             ▼
+            END
+```
+
+### 3.2 条件边 `route_after_parse`
+
+```python
+# backend/app/agents/graph.py:21-25
+def route_after_parse(state: AgentState) -> str:
+    if state.get("image_base64"):
+        return "image_agent"
+    return "retrieval"
+```
+
+判断逻辑：纯字符串检查 `image_base64` 字段是否非 None/非空。无需 LLM 判断，避免引入额外延迟和成本。
+
+### 3.3 并行检索的 3 路 asyncio.gather
+
+```python
+# backend/app/agents/retrieval.py:33-38
+procedure_task = asyncio.create_task(_retrieve("procedure", query, topic))
+rule_task      = asyncio.create_task(_retrieve("rule", query, topic))
+case_task      = asyncio.create_task(_retrieve("case", query, topic))
+
+procedure_docs, rule_docs, case_docs = await asyncio.gather(
+    procedure_task, rule_task, case_task
+)
+```
+
+三路检索并发执行，总耗时取决于最慢的一路，而非三路串行之和（预估节省约 60-70% 检索时间）。
+
+---
+
+## 4. 主题路由设计
+
+### 4.1 关键词打分逻辑
+
+```python
+# backend/app/agents/symptom_parser.py:25-40
+TOPIC_KEYWORDS = {
+    "vibration_swing": ["振动", "摆度", "抖动", "晃动", "位移", "瓦振", "轴振"],
+    "governor_oil":    ["调速器", "油压", "压油罐", "主配压阀", "导叶", "开度", "漏油"],
+    "bearing_temp":    ["轴承", "温度", "温升", "冷却水", "推力", "导轴承", "过热"],
+}
+```
+
+评分：遍历 `parsed_symptom.symptoms + device`，统计各 topic 关键词命中次数，取最高分 topic。若全零分，默认 `vibration_swing`。
+
+### 4.2 关键词 vs. LLM 分类的 Trade-off
+
+| 维度 | 关键词打分（当前） | LLM Zero-shot 分类（未来） |
+|------|------------------|--------------------------|
+| 延迟 | < 1ms | +500-1000ms（额外 LLM 调用） |
+| 成本 | 零 | 每次诊断增加 ~200 tokens |
+| 准确率 | 专业词典覆盖范围内高 | 覆盖新故障类型能力强 |
+| 可解释性 | 高（词命中可见） | 低（LLM 黑盒） |
+| 升级条件 | 故障类型 > 10 类 / 召回率 < 80% | — |
+
+### 4.3 TOPIC_KEYWORDS 的可扩展性
+
+新增故障类型只需在 `TOPIC_KEYWORDS` 字典中添加一个 key，并在知识库中添加对应的 `L2.TOPIC.XXX.001` 文档，以及在 `_CORPUS_FILTER_MAP`（`hybrid_retriever.py:13-18`）中注册对应 doc_id。
+
+---
+
+## 5. 业务约束（硬性约束，不可逾越）
+
+### 5.1 "辅助不替代"原则
+
+系统定位为**辅助决策工具**，所有输出必须附带不确定性声明。`report_draft`（`prompts.py:REPORT_GEN_PROMPT`）生成的交班汇报草稿包含"初步判断"字样，明确为辅助意见而非最终结论。
+
+**实现层面**：`DiagnosisResult` 模型中 `root_causes[].probability` 字段明确标注置信度，前端显示时附带"建议人工确认"提示。
+
+### 5.2 规则库优先于 LLM 判断
+
+`REASONING_PROMPT`（`prompts.py:65`）末尾指令：
+
+> 严格按 JSON 输出，不要其他文字。**风险等级判断依据规则库中的超限阈值与操作红线。**
+
+规则库（`L2.SUPPORT.RULE.001`）中的硬阈值（如"推力轴承温度 > 70°C 停机"）优先于 LLM 自由推理。即使 LLM 认为风险较低，只要规则库有明确红线，`risk_level` 必须升为 `critical`。
+
+### 5.3 Critical 风险强制输出升级理由
+
+`reasoning` 节点输出 `risk_level: "critical"` 时，`escalation_required` 必须为 `true`，`escalation_reason` 必须非空。前端检测到 critical 时显示强提示 UI（紫色 badge，强制滚动到风险提示区域）。
+
+### 5.4 不做自主控制指令
+
+系统输出仅为**诊断建议和检查步骤**，不产生任何直接发送至 SCADA/DCS 的控制指令。`check_steps[].caution` 字段明确标注危险操作的人工确认要求（如"操作前确认调速器在手动模式"）。
+
+Guardrails 层：
+- 前端不提供"一键执行"按钮，只有"复制步骤"功能
+- 后端无任何 SCADA 写入 API 接口
+
+---
+
+## 6. 当前能力边界（以现有语料为基准）
+
+### 6.1 覆盖场景
+
+| 故障类型 | topic 键 | 知识库覆盖 |
+|----------|----------|-----------|
+| 振动/摆度异常 | `vibration_swing` | L2.TOPIC.VIB.001 + L1 |
+| 调速器/油压异常 | `governor_oil` | L2.TOPIC.GOV.001 + L1 |
+| 轴承温度异常 | `bearing_temp` | L2.TOPIC.BEAR.001 + L1 |
+| 通用运维知识 | 所有 topic | L1.ROUTER.001 + L1.OVERVIEW.001 |
+| 规程规则 | 所有 topic | L2.SUPPORT.RULE.001 |
+| 历史案例 | 所有 topic | L2.SUPPORT.CASE.001 |
+
+### 6.2 当前不覆盖的场景
+
+- **厂站特定保护定值**：L3 未接入，当前规则库为通用行业标准值
+- **受限负荷区**：特定机组的振动敏感区需 L3 台账数据
+- **历次缺陷记录**：设备历史维修记录需 L3 缺陷库
+- **OCR 准确性**：不同 HMI 厂商（GE/ABB/国电南自）截图差异大，当前仅提取文本，不做结构化解析
+
+### 6.3 OCR 能力限制
+
+`image_agent` 节点调用 Claude vision API 进行文本提取，输出为 `ocr_text: str`（非结构化）。限制：
+- 报警列表图片可能提取顺序错乱
+- 曲线趋势图不做数值识别（仅描述趋势）
+- 截图分辨率 < 800px 时准确率下降
+
+---
+
+## 7. L3 语料接入后的扩展能力边界
+
+### 7.1 能力边界对比
+
+| 能力 | L3 为空（当前） | L3 完整接入 |
+|------|----------------|-------------|
+| 根因置信度 | 通用知识，置信度 0.4-0.6 | 本厂台账 + 历史数据，置信度可达 0.7-0.85 |
+| 阈值判断 | 行业通用标准（L2.SUPPORT.RULE） | 本厂保护定值（L3 专项定值库） |
+| 案例相似度 | 行业公开案例 | 本厂历次缺陷库，相似度匹配精度更高 |
+| 设备状态上下文 | 无 | 台账 → 设备年龄、上次检修时间、历史缺陷次数 |
+
+### 7.2 各 L3 文档接入后的扩展路径
+
+**接入 01_机组台账** → 根因置信度提升
+- 台账中的设备参数（额定转速、轴承型号）补充 reasoning 节点的上下文
+- 可判断"设备年龄超过大修周期"作为根因证据之一
+
+**接入 03_保护定值** → 阈值判断从通用 → 本厂专家
+- 替换 L2.SUPPORT.RULE.001 中的通用阈值
+- `risk_level` 判断更准确，减少误报和漏报
+
+**接入 05_历次缺陷** → 案例相似度检索维度新增
+- 新增 `plant_<id>_case` collection，优先级高于通用案例库
+- 相似案例检索的 RRF 融合权重可配置本厂案例优先
+
+---
+
+## 8. 未来架构扩展点
+
+### 8.1 人机交互节点（Human-in-the-loop）
+
+LangGraph 原生支持 `interrupt_before` / `interrupt_after` breakpoint：
+
+```python
+# 在 reasoning 之后暂停，等待专家确认根因假设
+graph.compile(interrupt_after=["reasoning"])
+```
+
+实现路径：
+1. SSE 推送 `status: {node: "reasoning", phase: "awaiting_human"}`
+2. 前端显示"专家确认"UI，运维人员选择/修正根因
+3. 前端 POST `/diagnosis/resume` 携带修正后的 state
+4. LangGraph 从 breakpoint 恢复执行
+
+### 8.2 多机组并发诊断
+
+当前 `session_id` 由客户端生成（UUID4），`AgentState` 生命周期限于单次请求，天然支持多并发。扩展点：
+- 跨 session 的机组状态关联（同一时刻多机组异常 → 可能是公共设备故障）
+- 需要引入 Redis 作为跨 session 状态存储
+
+### 8.3 Tool Calling 扩展（实时 SCADA 数据）
+
+LangGraph 支持 Tool Node，可在 reasoning 节点中调用实时数据查询工具：
+
+```python
+@tool
+async def query_scada(tag: str, time_range: str) -> dict:
+    """查询 SCADA 实时/历史数据"""
+    ...
+```
+
+约束：SCADA 连接为只读，不写入控制指令（符合 5.4 节业务约束）。

--- a/docs/03-rag-kb-design.md
+++ b/docs/03-rag-kb-design.md
@@ -1,0 +1,383 @@
+# 知识库分片、向量化、BM25 设计与版本管理策略
+
+## 1. 知识库四层结构与语料角色
+
+### 1.1 层级图
+
+```
+L0  基础规范层
+    └── 行业标准、国标、IEC 规范（不直接摄入，作为 L1/L2 编写依据）
+
+L1  总览路由层
+    ├── L1.ROUTER.001    — 症状 → 诊断路径路由表
+    └── L1.OVERVIEW.001  — 水电机组结构与运行原理总览
+
+L2  专题知识层
+    ├── L2.TOPIC.VIB.001  — 振动/摆度专题诊断指南
+    ├── L2.TOPIC.GOV.001  — 调速器/油压专题诊断指南
+    ├── L2.TOPIC.BEAR.001 — 轴承温度专题诊断指南
+    ├── L2.SUPPORT.RULE.001 — 硬阈值与操作红线规则库
+    └── L2.SUPPORT.CASE.001 — 行业典型故障案例库
+
+L3  厂站专有层（待接入）
+    ├── 01_机组台账       — 设备参数、检修历史
+    ├── 03_保护定值       — 本厂专项保护整定值
+    └── 05_历次缺陷       — 本厂历次缺陷记录
+```
+
+### 1.2 各层在 RAG 中的召回权重
+
+| 层级 | Corpus | 召回权重说明 |
+|------|--------|-------------|
+| L1 | procedure | 提供背景知识，召回频率高但内容通用 |
+| L2.TOPIC.* | procedure | 核心专题知识，与故障类型强相关 |
+| L2.SUPPORT.RULE | rule | 独立 collection，硬阈值判断专用 |
+| L2.SUPPORT.CASE | case | 独立 collection，案例相似度匹配 |
+| L3（待接入） | plant_<id>_* | 本厂专有，优先级最高 |
+
+### 1.3 YAML 前置元数据设计
+
+每个知识库文档以 YAML frontmatter 开头：
+
+```yaml
+---
+doc_id: L2.TOPIC.VIB.001
+title: 水电机组振动摆度诊断专题指南
+version: 1.0.0
+route_keys: [振动, 摆度, 轴振, 瓦振]
+upstream: [L1.ROUTER.001]
+downstream: [L2.SUPPORT.RULE.001, L2.SUPPORT.CASE.001]
+---
+```
+
+字段说明：
+- `doc_id`：全局唯一标识符，用于 corpus 过滤和 sources 追踪
+- `route_keys`：与 `TOPIC_KEYWORDS` 对应，用于检索路由
+- `upstream`：该文档的上游依赖（总览/路由文档）
+- `downstream`：该文档的下游扩展（规则/案例文档）
+
+---
+
+## 2. 渐进式披露分片策略（Progressive Disclosure Chunking）
+
+### 2.1 什么是渐进式披露
+
+渐进式披露（Progressive Disclosure）是指按信息重要性层次控制 context 填充：用户首先获得高层摘要（L1），按需深入专题细节（L2 TOPIC），最后获取支撑证据（L2 RULE/CASE）。
+
+在 RAG 场景中，这意味着：
+- reasoning 节点的 prompt 先填入 L1 总览（背景框架）
+- 再填入 L2 专题（核心知识）
+- 最后填入规则库和案例库（验证证据）
+- 总 context 长度控制在模型上下文窗口的 30-40% 以内
+
+### 2.2 两阶段分块策略
+
+实现文件：`backend/app/rag/chunker.py`
+
+**第一阶段：`MarkdownHeaderTextSplitter`**
+
+```python
+_HEADERS = [
+    ("#", "h1"),
+    ("##", "h2"),
+    ("###", "h3"),
+    ("####", "h4"),
+]
+header_splitter = MarkdownHeaderTextSplitter(
+    headers_to_split_on=_HEADERS,
+    strip_headers=False,  # 保留标题，使 chunk 具备自解释性
+)
+```
+
+按 Markdown 标题切分，每个 heading section 成为独立 chunk。标题保留在 chunk 内容中，使嵌入向量包含章节语义。
+
+**第二阶段：`RecursiveCharacterTextSplitter`（fallback）**
+
+```python
+_FALLBACK_SPLITTER = RecursiveCharacterTextSplitter(
+    chunk_size=600,
+    chunk_overlap=80,
+    separators=["\n\n", "\n", "。", "；", " ", ""],
+)
+```
+
+对 heading chunk 仍超过 600 字符的部分进一步切分。
+
+### 2.3 Chunk size=600 / overlap=80 的选择依据
+
+| 参数 | 值 | 依据 |
+|------|-----|------|
+| chunk_size | 600 | BGE-large-zh 嵌入上下文窗口 512 tokens，600 中文字符约 400-450 tokens，留余量 |
+| chunk_overlap | 80 | 约 chunk_size 的 13%，覆盖跨 chunk 边界的句子断裂；过大会增加存储和检索噪声 |
+
+600 字符的设计依据：
+- 水电运维知识段落平均长度约 200-400 字
+- chunk 太小（< 200）：语义碎片化，embedding 质量下降
+- chunk 太大（> 800）：超出 BGE 上下文窗口，尾部内容嵌入质量降低
+
+### 2.4 中文标点符号分隔符设计
+
+`separators=["\n\n", "\n", "。", "；", " ", ""]`
+
+分隔符优先级从高到低：
+1. `\n\n`：段落边界（最优切分点）
+2. `\n`：行边界
+3. `。`：中文句子结束（保证句子完整性）
+4. `；`：分号，适用于条目式规程
+5. ` `：空格（fallback，英文单词边界）
+6. `""`：字符级切分（最后手段）
+
+不使用英文 `.` 作为分隔符，避免将数字小数点（如 `0.85`）误切。
+
+### 2.5 元数据继承策略
+
+```python
+# chunker.py:43-45
+merged_meta = {**doc.metadata, **sc.metadata}
+chunks.append(Document(page_content=sc.page_content, metadata=merged_meta))
+```
+
+父文档 metadata（`doc_id`, `title`, `version`, `route_keys`）合并到每个 chunk 的 metadata 中，子 chunk 的 metadata 优先（`**sc.metadata` 在右侧覆盖父级同名字段）。
+
+这确保每个 chunk 携带完整的溯源信息，`sources` 字段可从任意 chunk 的 `doc_id` 追溯到原始文档。
+
+---
+
+## 3. 向量化设计
+
+### 3.1 BAAI/bge-large-zh-v1.5 选型依据
+
+| 模型 | 维度 | 中文专业术语质量 | 本地部署 | 成本 |
+|------|------|----------------|----------|------|
+| BAAI/bge-large-zh-v1.5 | 1024 | 优秀（MTEB 中文榜 Top 3） | 是 | 无 API 成本 |
+| text-embedding-3-large | 3072 | 良好 | 否（API） | $0.13/MTok |
+| m3e-base | 768 | 中等（通用中文） | 是 | 无 |
+| BAAI/bge-m3 | 1024 | 优秀（多语言） | 是 | 无 |
+
+水电运维术语（如"导叶反馈信号不一致"、"压油罐补气阀"）属于低频专业词汇，需要在 MTEB 中文语义相似度任务上表现优秀的模型。bge-large-zh-v1.5 在此类任务上优于通用模型。
+
+### 3.2 1024-dim cosine similarity 的性能影响
+
+1024 维向量的 cosine 相似度计算（FAISS/Qdrant）：
+- 单次查询延迟（10K 向量）：< 5ms（CPU），< 1ms（GPU）
+- 存储：每个 chunk 1024 × 4 bytes = 4KB，10K chunks ≈ 40MB（可接受）
+- 与 768 维相比：质量提升约 5-8%，存储/计算成本增加约 33%
+
+### 3.3 三独立 Collection 设计
+
+| Collection | doc_ids | 用途 |
+|------------|---------|------|
+| `hydro_kb_procedure` | L2.TOPIC.* + L1.* | 诊断流程和背景知识 |
+| `hydro_kb_rule` | L2.SUPPORT.RULE.001 | 硬阈值和操作红线 |
+| `hydro_kb_case` | L2.SUPPORT.CASE.001 | 历史相似案例 |
+
+Collection 隔离的好处：
+- **语义隔离**：规则库的强断言语言（"必须"、"严禁"）不会污染案例库的叙述性语言的语义空间
+- **过滤效率**：检索时直接指定 collection，无需 metadata 后过滤
+- **独立更新**：规则库更新不触发 procedure/case collection 重建
+
+---
+
+## 4. BM25 设计
+
+### 4.1 jieba 分词在水电专业术语上的行为
+
+jieba 默认词典对通用中文分词效果好，但水电专业术语可能被错误切分：
+
+| 原词 | jieba 默认切分 | 期望切分 |
+|------|--------------|---------|
+| 导叶开度 | 导叶 / 开度 | 导叶开度（应保持整体） |
+| 压油罐 | 压 / 油罐 | 压油罐 |
+| 主配压阀 | 主 / 配压阀 | 主配压阀 |
+| 调速器 | 调速 / 器 | 调速器 |
+
+由于 jieba 会将"导叶"和"开度"分开，BM25 层面的精确匹配依赖于 tokenized query 和 tokenized document 的重叠，通用词典下仍能覆盖大多数场景。
+
+### 4.2 自定义专业词典接入路径
+
+```python
+# 在 bm25_index.py 初始化时加载专业词典
+import jieba
+jieba.load_userdict("./knowledge_base/hydro_dict.txt")
+```
+
+`hydro_dict.txt` 格式（每行：词语 频率 词性）：
+```
+压油罐 10 n
+主配压阀 10 n
+导叶开度 10 n
+推力轴承 10 n
+```
+
+接入后，上述专业术语在分词时保持整体，BM25 召回精度提升（P2 优化项）。
+
+### 4.3 BM25Okapi 参数说明
+
+`BM25Okapi` 使用 `rank_bm25` 库（`backend/app/rag/bm25_index.py:23`），默认参数：
+
+- `k1 = 1.5`：词频饱和因子。高 k1 使词频增加带来的分数提升更平滑，适合长文档（水电规程文档通常 500-2000 字）
+- `b = 0.75`：文档长度归一化因子。b=0.75 在不归一化（b=0）和完全归一化（b=1）之间取中，适合长度差异大的混合语料（L1 总览文档 vs. L2 专题细节）
+
+### 4.4 Pickle 持久化策略与增量更新限制
+
+```python
+# BM25Index.save / load
+def save(self, path: str | Path) -> None:
+    with open(path, "wb") as f:
+        pickle.dump(self, f)
+```
+
+文件路径：`./knowledge_base/vector_store/bm25_<corpus>.pkl`
+
+**限制**：BM25Okapi 的 IDF 值在构建时基于整个语料库计算，不支持增量更新。添加新文档必须重建整个索引（`ingest_kb.py --reset`）。
+
+**影响**：当前 KB 文档量较小（< 100 文档），重建耗时 < 10s，可接受。文档量 > 1000 时需考虑分批重建策略。
+
+---
+
+## 5. 混合检索 RRF 融合
+
+### 5.1 Reciprocal Rank Fusion 公式
+
+$$\text{RRF\_score}(d) = \sum_{r \in R} \frac{1}{k + \text{rank}_r(d)}$$
+
+其中：
+- $R$：所有参与融合的排序列表（BM25 结果列表 + Dense 结果列表）
+- $k = 60$：平滑常数
+- $\text{rank}_r(d)$：文档 $d$ 在排序列表 $r$ 中的排名（从 0 开始）
+
+实现参考：`backend/app/rag/hybrid_retriever.py:21-36`
+
+### 5.2 为何 k=60
+
+`k=60` 是 RRF 的经典默认值（Cormack et al., 2009），对头部结果的平滑效果：
+
+| rank | k=0, score | k=60, score | 差异 |
+|------|-----------|------------|------|
+| 0（第1名） | 1.000 | 0.0164 | 平滑后头部优势减小 |
+| 1（第2名） | 0.500 | 0.0161 | 头部间差异缩小 |
+| 10（第11名） | 0.091 | 0.0141 | 中部文档获得合理分数 |
+| 59（第60名） | 0.017 | 0.0083 | 尾部依然有贡献 |
+
+k=60 防止单一排序列表中的第1名对最终结果产生过度主导，使 BM25 和 Dense 两种信号能平衡融合。
+
+### 5.3 BM25 与 Dense 权重对等
+
+当前实现中 BM25 结果列表和 Dense 结果列表在 RRF 中权重相等（均传入 `lists` 数组一次）。
+
+不预设偏向的理由：
+- 水电运维查询中，术语精确匹配（BM25 优势）和语义相似度（Dense 优势）同等重要
+- 具体偏向应基于实际召回评估数据调整，而非预设（见第 7 节评估体系）
+
+如需调整权重，可通过重复传入某个列表实现（如传入 Dense 列表两次相当于 2:1 权重）。
+
+### 5.4 Reranker 降级路径
+
+```python
+# hybrid_retriever.py:74-85
+def _rerank(query: str, docs: list[Document]) -> list[Document]:
+    try:
+        from FlagEmbedding import FlagReranker
+        reranker = FlagReranker(settings.reranker_model, use_fp16=True)
+        pairs = [[query, d.page_content] for d in docs]
+        scores = reranker.compute_score(pairs)
+        ranked = sorted(zip(scores, docs), key=lambda x: x[0], reverse=True)
+        return [d for _, d in ranked]
+    except Exception:
+        return docs  # 降级：返回 RRF 融合结果
+```
+
+`FlagEmbedding` 库未安装时（或 GPU 内存不足时），`except Exception` 捕获所有异常，直接返回 RRF 融合结果。这确保检索功能不因 reranker 缺失而中断，只是召回质量略有下降。
+
+---
+
+## 6. 知识库版本管理策略（未来）
+
+### 6.1 语义化版本规范
+
+```
+KB 版本格式：v{major}.{minor}.{patch}
+
+v1.0.0 = L0 + L1 + L2（基础版）
+v1.1.0 = v1.0.0 + L3_plant_yantan（接入滩坝电站 L3）
+v1.2.0 = v1.1.0 + L3_plant_longtan（接入龙滩电站 L3）
+v2.0.0 = 新增故障类型（如发电机励磁异常）
+```
+
+### 6.2 向量库版本化方案
+
+Collection 命名加 version suffix：
+```
+hydro_kb_procedure_v1
+hydro_kb_procedure_v2  ← 新版本迁移完成前新旧并存
+```
+
+迁移策略：新版本 collection 建立后，通过 `config.py` 切换指向，旧 collection 保留 7 天后删除。
+
+### 6.3 BM25 与 Vector Store 的同步一致性
+
+`ingest_kb.py` 保证两者在同一次运行中原子更新：
+
+```
+ingest_kb.py --reset
+    ├── 1. 清空 Chroma collection（或指定的 Qdrant collection）
+    ├── 2. 重新摄入所有文档（chunk → embed → upsert）
+    └── 3. 重建 BM25 index → 保存 pkl 文件
+```
+
+`--reset` 标志防止向量库和 BM25 索引出现版本不一致（如只更新了向量库但未重建 BM25）。
+
+### 6.4 增量摄入策略（P2）
+
+基于 content hash 的增量更新：
+1. 摄入时计算每个文档的 `sha256(content)`，存储到 metadata
+2. 再次摄入时对比 hash，仅重新处理变更文档
+3. BM25 index 仍需全量重建（受 BM25Okapi IDF 计算限制）
+
+### 6.5 多电厂命名空间隔离
+
+Collection 命名规范：`plant_<plant_id>_<corpus>`
+
+```
+plant_yantan_procedure
+plant_yantan_rule
+plant_yantan_case
+plant_longtan_procedure
+...
+```
+
+BM25 index 文件：`bm25_plant_<plant_id>_<corpus>.pkl`
+
+查询时通过请求中的 `plant_id` 参数路由到对应 collection（`retrieval.py` 中 `get_retriever(corpus)` 接受 `plant_id` 参数扩展）。
+
+---
+
+## 7. 质量评估体系（scripts/eval_retrieval.py 占位）
+
+### 7.1 评估指标
+
+| 指标 | 说明 | 目标值（预估） |
+|------|------|---------------|
+| Top-5 Recall | 相关文档出现在前 5 名的比例 | > 0.85 |
+| MRR | Mean Reciprocal Rank，第一个相关文档的倒数排名均值 | > 0.75 |
+| NDCG@10 | Normalized Discounted Cumulative Gain，考虑相关性等级 | > 0.80 |
+
+### 7.2 黄金标准测试集构建建议
+
+建议构建 3 个故障场景 × 5 个查询变体 = 15 个测试用例：
+
+| 场景 | 查询变体示例 | 期望召回文档 |
+|------|------------|-------------|
+| 振动摆度异常 | "1号机组摆度偏大"、"轴振超标" | L2.TOPIC.VIB.001, L2.SUPPORT.RULE.001 |
+| 调速器油压低 | "压油罐压力不足"、"导叶无法开启" | L2.TOPIC.GOV.001, L2.SUPPORT.RULE.001 |
+| 推力轴承温升 | "推力轴承温度高"、"冷却水流量不足" | L2.TOPIC.BEAR.001, L2.SUPPORT.CASE.001 |
+
+### 7.3 评估执行方式（占位）
+
+```bash
+# 待实现
+python scripts/eval_retrieval.py \
+  --test-set knowledge_base/eval/golden_set.jsonl \
+  --corpus procedure rule case \
+  --metrics recall mrr ndcg
+```

--- a/docs/04-sse-streaming.md
+++ b/docs/04-sse-streaming.md
@@ -1,0 +1,348 @@
+# SSE 流式诊断设计、全链路考量与性能量化
+
+## 1. 为什么需要流式输出
+
+### 1.1 LangGraph 5 节点推理链的典型耗时
+
+| 节点 | 耗时来源 | 预估耗时（P50） |
+|------|---------|----------------|
+| `symptom_parser` | LLM JSON 解析（~300 tokens） | 1.5-2.5s |
+| `image_agent`（可选）| Claude vision OCR | 2-4s |
+| `retrieval` | 3 路并行 BM25 + Dense 检索 | 0.5-1.5s |
+| `reasoning` | LLM 根因推理（~800 tokens 输出） | 4-8s |
+| `report_gen` | LLM 步骤生成（~500 tokens 输出） | 3-6s |
+| **总计（无图片）** | | **9-18s** |
+| **总计（含图片）** | | **11-22s** |
+
+*注：以上为预估值，基于 claude-sonnet-4-6 API 延迟经验值，实际受网络条件影响。*
+
+### 1.2 无流式方案的用户体验问题
+
+无流式（`await graph.ainvoke()`）：
+- 用户提交查询后看到空白页面或 loading spinner
+- 等待 9-18 秒无任何反馈
+- 用户无法判断系统是否在工作，倾向于重复提交或放弃
+- 水电运维场景下，运维人员在紧急故障时等待超过 5 秒会显著降低信任感
+
+### 1.3 有流式方案的用户体验提升
+
+SSE 流式输出：
+- 首字节（第一个 `status` 事件）< 800ms（symptom_parser 节点启动）
+- 节点进度实时可见（"正在分析症状..." → "正在检索知识库..." → "正在推理根因..."）
+- reasoning/report_gen 节点的 LLM token 实时显示，用户看到诊断内容逐字生成
+- 感知等待时间减少约 60-70%（业界流式 UX 研究结论）
+
+---
+
+## 2. 技术选型：SSE vs. WebSocket vs. Long-polling
+
+| 维度 | SSE | WebSocket | Long-polling |
+|------|-----|-----------|--------------|
+| 协议 | HTTP/1.1, HTTP/2 | ws:// (升级协议) | HTTP/1.1 |
+| 方向 | 单向（服务端→客户端） | 双向 | 单向（响应式） |
+| 断线重连 | 浏览器原生自动重连 | 需手工实现 | 需手工实现 |
+| 浏览器原生支持 | `EventSource` API | `WebSocket` API | `fetch` |
+| HTTP 中间件兼容性 | 高（Nginx/CDN 原生支持） | 需配置 Upgrade 头 | 高 |
+| 实现复杂度 | 低 | 中 | 中 |
+| HTTP/2 多路复用 | 支持（不占用额外连接） | 不适用 | 支持 |
+| POST body 支持 | 需用 fetch（非 EventSource） | 握手后发送 | 支持 |
+
+**选择 SSE 的核心理由：**
+
+1. **单向推送足够**：诊断请求是"提交 → 等待结果"模式，无需客户端在流式过程中向服务端发送数据
+2. **HTTP 兼容性好**：Nginx、AWS ALB、Cloudflare 等中间件对 SSE 有原生支持，仅需配置 `proxy_buffering off`
+3. **FastAPI 原生支持**：`StreamingResponse(media_type="text/event-stream")` 即可，无需额外库
+4. **断线重连**：浏览器 `EventSource` 原生支持自动重连（本项目使用 `fetch` 实现，手动处理 abort）
+
+---
+
+## 3. 全链路 SSE 架构
+
+### 3.1 端到端数据流
+
+```
+LangGraph.astream_events(state)
+        │
+        │  on_chain_start/end → {"node": "symptom_parser", "phase": "start"}
+        │  on_chat_model_stream → {"text": "推力轴承..."}
+        ▼
+streaming.py:stream_agent_events()
+  [AsyncIterator[str]]
+        │
+        │  "event: status\ndata: {...}\n\n"
+        │  "event: token\ndata: {...}\n\n"
+        ▼
+diagnosis.py:event_generator()
+  [AsyncGenerator]
+        │
+        │  (streaming 完成后)
+        │  → graph.ainvoke(state)    ← 双调用（获取最终结构化结果）
+        │  "event: result\ndata: {...}\n\n"
+        ▼
+FastAPI StreamingResponse
+  [text/event-stream]
+        │
+        │  HTTP chunked transfer encoding
+        ▼
+浏览器 fetch + ReadableStream
+  (diagnosisApi.ts:streamDiagnosis)
+        │
+        │  buffer 拼接 + SSE 解析
+        │  onStatus() / onToken() / onResult() / onError()
+        ▼
+useDiagnosisStore (Zustand)
+  │  setPhase(node)
+  │  appendToken(text)   ← streamText += text
+  │  setResult(result)
+        ▼
+React 组件（DiagnosisPanel）
+  实时渲染 streamText + phase 进度条
+```
+
+### 3.2 4 种事件类型设计意图
+
+| 事件类型 | 数据格式 | 触发时机 | 前端处理 |
+|----------|---------|---------|---------|
+| `status` | `{"node": "reasoning", "phase": "start"}` | 每个节点开始/结束 | 更新 `phase`，显示进度指示器 |
+| `token` | `{"text": "推力轴承..."}` | LLM 每个 token 输出 | `appendToken(text)`，实时显示流式文字 |
+| `result` | `DiagnosisResult` 完整 JSON | 所有节点执行完毕后 | `setResult(result)`，渲染结构化诊断卡 |
+| `error` | `{"message": "..."}` | 任意节点异常 | `setError(message)`，显示错误提示 |
+
+### 3.3 SSE 消息格式规范
+
+```
+event: status
+data: {"node": "symptom_parser", "phase": "start"}
+
+event: token
+data: {"text": "根据症状分析，"}
+
+event: result
+data: {"session_id": "...", "root_causes": [...], "risk_level": "high", ...}
+
+event: error
+data: {"message": "symptom_parser failed: ..."}
+```
+
+规范：每条消息以 `\n\n` 结尾，`event:` 和 `data:` 字段各占一行，值为 UTF-8 JSON 字符串（`ensure_ascii=False`）。
+
+实现参考：`backend/app/utils/streaming.py:9-12`
+
+---
+
+## 4. 双调用模式（Double-invocation Pattern）
+
+### 4.1 问题背景
+
+LangGraph 的 `astream_events` 是**流式执行事件流**，它逐步触发节点执行的事件（`on_chain_start`, `on_chat_model_stream` 等），但**不直接返回最终 `AgentState`**。
+
+流式阶段只能获取 token 片段，无法直接获取 `root_causes`, `check_steps`, `risk_level` 等结构化字段。
+
+### 4.2 当前解决方案
+
+```python
+# diagnosis.py:51-76
+async def event_generator():
+    # 第一次调用：流式推送 token 和 status 事件
+    async for chunk in stream_agent_events(graph, initial_state):
+        yield chunk
+
+    # 第二次调用：获取最终结构化 state
+    final_state = await graph.ainvoke(initial_state)
+    result = DiagnosisResult(...)
+    yield await sse_format("result", result.model_dump())
+```
+
+### 4.3 代价分析
+
+| 代价项 | 说明 |
+|--------|------|
+| LLM 调用次数 | 每次诊断请求触发 2 倍 LLM 调用（reasoning + report_gen 各调用 2 次） |
+| 延迟增加 | `ainvoke` 在 `astream_events` 完成后执行，总延迟约增加 50-100%（预估） |
+| 成本增加 | token 消耗约翻倍 |
+
+### 4.4 P2 优化方向
+
+在 `astream_events` 的 `on_chain_end` 回调中捕获最终节点输出：
+
+```python
+elif kind == "on_chain_end" and name == "report_gen":
+    # astream_events v2 的 on_chain_end 包含节点输出
+    output = event.get("data", {}).get("output", {})
+    # 从 output 中提取最终 state，直接构建 DiagnosisResult
+    # → 无需第二次 ainvoke
+```
+
+这需要验证 `astream_events version="v2"` 是否在 `on_chain_end` 事件中返回完整节点输出（LangGraph 版本依赖）。
+
+---
+
+## 5. 响应头设计
+
+实现参考：`backend/app/api/routes/diagnosis.py:78-86`
+
+```python
+return StreamingResponse(
+    event_generator(),
+    media_type="text/event-stream",
+    headers={
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",
+        "Connection": "keep-alive",
+    },
+)
+```
+
+| 响应头 | 值 | 作用 |
+|--------|-----|------|
+| `Cache-Control` | `no-cache` | 禁止浏览器和中间代理缓存 SSE 响应 |
+| `X-Accel-Buffering` | `no` | 禁用 Nginx `proxy_buffering`（关键！否则 Nginx 会缓冲响应直到连接关闭） |
+| `Connection` | `keep-alive` | 维持长连接，防止中间代理超时断开 |
+
+**注意**：Nginx 配置还需在 `location` 块中设置：
+```nginx
+proxy_buffering off;
+proxy_cache off;
+proxy_read_timeout 300s;
+```
+
+---
+
+## 6. 前端消费设计
+
+### 6.1 选择 `fetch + ReadableStream` 而非 `EventSource` API
+
+| 维度 | EventSource | fetch + ReadableStream |
+|------|-------------|----------------------|
+| HTTP 方法 | 仅 GET | GET/POST（本项目需要 POST body） |
+| 自定义请求头 | 不支持 | 支持（Bearer token 等） |
+| 请求体 | 不支持 | 支持（`DiagnosisRequest` JSON） |
+| AbortController | 不原生支持 | 原生支持 |
+| 浏览器兼容性 | IE 不支持（不影响本项目） | 现代浏览器全支持 |
+
+本项目诊断请求需要 POST body（`query`, `image_base64`, `session_id`），因此必须使用 `fetch`。
+
+### 6.2 Buffer 拼接处理（粘包/分包）
+
+SSE 消息可能跨 chunk 边界（TCP 分包）或一个 chunk 中包含多条消息（粘包）。前端需要维护 buffer：
+
+```typescript
+// diagnosisApi.ts（示意，实际实现见源码）
+let buffer = "";
+
+reader.read() → chunk
+buffer += chunk
+const parts = buffer.split("\n\n")
+buffer = parts.pop()  // 最后一个可能不完整，留存 buffer
+for (const part of parts) {
+    parseSSEMessage(part)  // event: xxx / data: xxx
+}
+```
+
+### 6.3 AbortController 的 cancel 机制
+
+```typescript
+// useSSEDiagnosis.ts:13-21
+const abortRef = useRef<AbortController | null>(null);
+
+const run = useCallback(async (request) => {
+    abortRef.current?.abort();  // 取消上一次请求
+    abortRef.current = new AbortController();
+    // ...
+    await streamDiagnosis(request, handlers, abortRef.current.signal);
+}, [...]);
+
+const abort = useCallback(() => {
+    abortRef.current?.abort();
+    setPhase("idle");
+}, [setPhase]);
+```
+
+用户切换页面或主动取消时，`AbortController.abort()` 触发 `fetch` 中止，服务端的 `StreamingResponse` generator 在下次 `yield` 时感知到客户端断开并退出。
+
+### 6.4 Zustand `appendToken` 实时渲染
+
+```typescript
+// diagnosisStore.ts:42-44
+appendToken: (text) =>
+    set((state) => ({ streamText: state.streamText + text })),
+```
+
+`appendToken` 在每个 token 事件时调用，`streamText` 字段累积所有 token。React 组件通过 `useDiagnosisStore(s => s.streamText)` 订阅，仅当 `streamText` 变化时重渲染该组件，不触发其他组件更新。
+
+---
+
+## 7. 性能量化指标
+
+### 7.1 基线：无流式方案延迟
+
+| 指标 | 预估值（无图片） | 预估值（含图片） |
+|------|----------------|----------------|
+| P50 端到端延迟 | 9-12s | 12-18s |
+| P95 端到端延迟 | 15-20s | 20-28s |
+| 用户等待感知 | 全程白屏/spinner | 全程白屏/spinner |
+
+*注：预估值，实际受 API 负载和网络延迟影响。*
+
+### 7.2 流式方案目标指标
+
+| 指标 | 目标值 | 说明 |
+|------|--------|------|
+| TTFT（Time To First Token）| < 800ms | 从提交到第一个 `status` 事件 |
+| 首个 LLM token 可见 | < 3s | symptom_parser 完成 + reasoning 开始 |
+| 感知等待时间减少 | ~60-70% | 业界流式 UX 标准（Shneiderman 响应时间法则） |
+| SSE 事件频率 | 10-50 events/s | reasoning 节点 token 流密集期 |
+
+### 7.3 Token 吞吐
+
+claude-sonnet-4-6 典型输出速度：约 60-80 tokens/s（预估，受服务器负载影响）。
+
+reasoning 节点输出约 400-600 tokens（根因 + 风险判断），流式持续时间约 5-10s，用户体验为"看到诊断内容逐渐生成"。
+
+### 7.4 SSE 带宽开销
+
+| 事件类型 | 典型大小 | 每次诊断数量 | 总计 |
+|----------|---------|-------------|------|
+| `status` | ~80 bytes | ~10 | ~800 bytes |
+| `token` | ~50 bytes | ~500-800 | ~25-40 KB |
+| `result` | ~2-5 KB | 1 | ~2-5 KB |
+| **总计** | | | **~28-46 KB** |
+
+每次诊断 SSE 流量约 30-50 KB，相比诊断本身的价值可完全忽略。
+
+---
+
+## 8. 已知限制与 P2 优化方向
+
+### 8.1 HTTP/1.1 连接限制
+
+HTTP/1.1 下，每个 SSE 连接占用一个持久 TCP socket。浏览器对同一域名的并发连接数限制为 6（HTTP/1.1 规范）。
+
+影响：用户同时开启多个诊断标签页时，超过 6 个并发 SSE 连接会被队列化。
+
+缓解：升级到 HTTP/2（Nginx `http2` 配置），SSE 通过多路复用不占用额外连接。
+
+### 8.2 Nginx 代理缓冲配置
+
+生产部署时必须在 Nginx 中关闭代理缓冲，否则 SSE 消息会在 Nginx buffer 中积累，导致"批量发送"效果（失去流式体验）：
+
+```nginx
+location /api/diagnosis/ {
+    proxy_pass http://backend:8000;
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 300s;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+}
+```
+
+### 8.3 双调用问题的根因与修复方案
+
+**根因**：LangGraph `astream_events` API 设计为事件流，不返回 state 快照。`ainvoke` 是唯一能获取最终完整 state 的同步接口。
+
+**修复方案（P2）**：
+1. 在 `astream_events` 的 `on_chain_end` 事件中，当 `name == "report_gen"` 时，尝试从 `event["data"]["output"]` 提取最终 state（需验证 LangGraph API 支持）
+2. 或在 `report_gen` 节点内部将最终结果写入 `stream_tokens`，`stream_agent_events` 在接收到特殊标记 token 时解析完整 state
+
+**当前接受双调用代价的理由**：诊断结果的正确性优先于 API 调用效率；P2 优化在确认 LangGraph API 行为后进行。

--- a/docs/05-langsmith-integration.md
+++ b/docs/05-langsmith-integration.md
@@ -1,0 +1,315 @@
+# LangSmith 可观测性集成：架构、配置与使用指南
+
+## 1. 为什么需要 LLM 可观测性
+
+### 1.1 传统 APM 的盲区
+
+传统应用性能监控（Datadog, New Relic 等）追踪的是函数调用链路和 HTTP 响应时间，对 LLM 应用存在以下盲区：
+
+| 盲区 | 说明 |
+|------|------|
+| Prompt 内容不可见 | 无法知道 LLM 实际收到了什么 prompt |
+| Token 消耗不透明 | 无法按节点追踪 input/output token 数 |
+| 推理链不可审计 | 无法回溯特定诊断结果的推理过程 |
+| 模型输出质量 | 无法追踪 JSON 解析失败率、幻构字段率 |
+| 检索质量 | 无法知道 RAG 命中了哪些文档 |
+
+### 1.2 水电诊断场景的特殊需求
+
+水电运维是**高责任场景**：每次诊断输出都可能影响实际操作决策。因此：
+
+- **每次诊断的完整推理链必须可审计**：事后能回溯"为什么给出这个根因"
+- **错误诊断需要快速定位**：是 retrieval 问题（召回错误文档）还是 reasoning 问题（LLM 推理错误）
+- **知识库更新后需验证质量**：新增 L3 文档后，确认诊断质量提升而非下降
+
+---
+
+## 2. LangSmith 集成架构
+
+### 2.1 集成方式
+
+LangSmith 通过环境变量自动拦截所有 LangChain/LangGraph 调用，无需修改业务代码：
+
+```bash
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_API_KEY=ls__xxxxxxxxxxxx
+LANGCHAIN_PROJECT=hydro-om-copilot
+```
+
+设置后，所有经过 LangChain 的 LLM 调用、链调用、工具调用自动上传到 LangSmith。
+
+配置来源：`backend/app/config.py:38-40`
+
+```python
+langchain_tracing_v2: bool = False
+langchain_api_key: str = ""
+langchain_project: str = "hydro-om-copilot"
+```
+
+### 2.2 Trace 层级
+
+```
+Project: hydro-om-copilot
+└── Run (1 次诊断请求，session_id = xxx)
+    ├── symptom_parser  [Node Span]
+    │   └── ChatAnthropic  [LLM Span]
+    │       ├── input:  SYMPTOM_PARSER_PROMPT + query
+    │       ├── output: {"unit_id": ..., "symptoms": [...]}
+    │       └── usage:  {input_tokens: 120, output_tokens: 85}
+    ├── retrieval  [Node Span]
+    │   ├── HybridRetriever.procedure  [Retrieval Span]
+    │   ├── HybridRetriever.rule       [Retrieval Span]
+    │   └── HybridRetriever.case       [Retrieval Span]
+    ├── reasoning  [Node Span]
+    │   └── ChatAnthropic  [LLM Span]
+    │       ├── input:  REASONING_PROMPT + context
+    │       ├── output: {"root_causes": [...], "risk_level": "high"}
+    │       └── usage:  {input_tokens: 1800, output_tokens: 420}
+    └── report_gen  [Node Span]
+        └── ChatAnthropic  [LLM Span]
+            ├── input:  REPORT_GEN_PROMPT + root_causes
+            ├── output: {"check_steps": [...], "report_draft": "..."}
+            └── usage:  {input_tokens: 600, output_tokens: 380}
+```
+
+### 2.3 与 LangGraph 的原生集成
+
+LangGraph 每个节点（`symptom_parser`, `retrieval`, `reasoning`, `report_gen`）在 LangSmith 中自动成为独立 Span，携带：
+- 节点名称和执行时间
+- 输入 state（可选，通过 `langchain_verbose=True` 启用）
+- 输出 state diff
+- 子调用（LLM、工具）的完整链路
+
+无需手工添加任何 tracing 代码。
+
+---
+
+## 3. 配置说明
+
+### 3.1 `.env.example` 中的配置项
+
+```bash
+# LangSmith 可观测性（可选，本地开发可不填）
+LANGCHAIN_TRACING_V2=false          # 本地开发：禁用
+LANGCHAIN_API_KEY=                  # 生产：填入 LangSmith API Key
+LANGCHAIN_PROJECT=hydro-om-copilot  # 项目名称（按电厂可自定义）
+# LANGCHAIN_ENDPOINT=https://api.smith.langchain.com  # 默认值，私有化部署时修改
+```
+
+### 3.2 环境配置策略
+
+| 环境 | `LANGCHAIN_TRACING_V2` | 说明 |
+|------|----------------------|------|
+| 本地开发 | `false` | 无需 API Key，节省配置成本 |
+| CI/CD | `false` | 测试运行不上传 trace |
+| Staging | `true` | 验证 trace 完整性，project 名加 `-staging` 后缀 |
+| 生产 | `true` | 全量上传，按电厂隔离 project |
+
+### 3.3 多电厂 Project 命名建议
+
+```bash
+# 电厂 A 生产
+LANGCHAIN_PROJECT=hydro-om-yantan-prod
+
+# 电厂 B 生产
+LANGCHAIN_PROJECT=hydro-om-longtan-prod
+
+# 通用测试
+LANGCHAIN_PROJECT=hydro-om-copilot-dev
+```
+
+每个 Project 独立的好处：在 LangSmith UI 中可按电厂筛选 trace，便于分析不同电厂的诊断质量差异。
+
+### 3.4 数据隐私处理建议
+
+LangSmith 默认将完整 prompt（含用户 query）上传至 LangSmith 服务器（Anthropic/US-East 托管）。
+
+水电运维场景的敏感字段：
+- `raw_query`：运维人员描述的故障症状（可能含设备编号、运行参数）
+- `image_base64`：HMI 截图（包含实时运行数据）
+
+建议：
+1. **生产环境**：使用 `LANGCHAIN_HIDE_INPUTS=true` 隐藏 LLM 输入（仅保留 token 计数和延迟）
+2. **或使用自托管 LangSmith**（见第 6 节）
+3. **最小化方案**：关闭 LangSmith，仅使用结构化日志记录 session_id、risk_level、sources（不含用户 query）
+
+---
+
+## 4. 可追踪指标
+
+### 4.1 Token 消耗（按节点）
+
+通过 LangSmith UI 可按节点查看每次诊断的 token 消耗：
+
+| 节点 | 典型 input tokens | 典型 output tokens | 累计成本（预估） |
+|------|-----------------|------------------|----------------|
+| symptom_parser | ~120 | ~80 | $0.0003 |
+| reasoning | ~1500-2000 | ~400-600 | $0.005-0.008 |
+| report_gen | ~600-800 | ~350-500 | $0.002-0.004 |
+| **总计** | | | **~$0.008-0.013/次** |
+
+*注：基于 claude-sonnet-4-6 定价预估，实际以 Anthropic 官方定价为准。*
+
+### 4.2 各节点耗时
+
+LangSmith Trace 时间线视图显示每个 Span 的开始/结束时间，可识别：
+- 哪个节点是瓶颈（通常是 reasoning）
+- retrieval 的并行效果（3 路检索在 timeline 中并排显示）
+- LLM TTFT（Span 开始到第一个 token 的时间）
+
+### 4.3 RAG 检索命中文档追踪
+
+`retrieval` 节点将 `sources`（doc_id 列表）写入 AgentState：
+
+```python
+# retrieval.py:41-43
+sources = list(
+    {doc["doc_id"] for doc in procedure_docs + rule_docs + case_docs if "doc_id" in doc}
+)
+```
+
+这些 `sources` 在 LangSmith 的 Span 输出中可见，用于分析：
+- 哪些文档被高频命中（可能需要内容优化）
+- 哪些查询没有命中预期文档（retrieval 质量问题）
+- 规则库命中率（`L2.SUPPORT.RULE.001` 是否总在 critical 场景中被召回）
+
+### 4.4 错误率与失败节点定位
+
+LangSmith 在 Trace 列表中标记失败的 Run（红色），点击可查看：
+- 哪个节点抛出异常
+- 完整的 error traceback
+- 失败时的 input state（便于复现）
+
+---
+
+## 5. 评估（Evaluation）接入
+
+### 5.1 LangSmith Dataset + Evaluator 基本使用
+
+1. **创建 Dataset**：在 LangSmith UI 中上传黄金标准测试集（见 `03-rag-kb-design.md` 第 7 节）
+2. **运行评估**：`client.evaluate(target_function, data=dataset, evaluators=[...])`
+3. **查看结果**：LangSmith UI 中对比不同 prompt 版本的评估分数
+
+### 5.2 为 3 类诊断场景创建 Golden Dataset
+
+```json
+[
+  {
+    "inputs": {"query": "1号机组推力轴承温度持续升高，冷却水流量正常"},
+    "outputs": {
+      "expected_root_causes": ["推力瓦面磨损", "油膜破裂"],
+      "expected_risk_level": "high",
+      "expected_sources_contains": ["L2.TOPIC.BEAR.001"]
+    }
+  },
+  {
+    "inputs": {"query": "调速器油压低，压油罐压力 2.8MPa（额定 3.2MPa）"},
+    "outputs": {
+      "expected_root_causes": ["补气阀故障", "漏油"],
+      "expected_risk_level": "high",
+      "expected_sources_contains": ["L2.TOPIC.GOV.001", "L2.SUPPORT.RULE.001"]
+    }
+  }
+]
+```
+
+### 5.3 自定义 Evaluator：诊断根因匹配率
+
+```python
+def root_cause_match_evaluator(run, example):
+    """检查 top-1 根因是否匹配专家标注"""
+    predicted = run.outputs.get("root_causes", [{}])[0].get("title", "")
+    expected_keywords = example.outputs.get("expected_root_cause_keywords", [])
+    match = any(kw in predicted for kw in expected_keywords)
+    return {"score": 1 if match else 0, "key": "root_cause_match"}
+```
+
+**注**：此 evaluator 需专家标注 golden dataset，目前为占位设计。建议在 L3 语料接入后，由厂站专家提供 10-20 个真实诊断案例作为标注基础。
+
+---
+
+## 6. 替代方案（私有化部署 / 数据不出境）
+
+### 6.1 LangSmith 自托管版本
+
+LangSmith Enterprise 支持在企业私有云部署，Trace 数据不上传至 LangSmith SaaS。
+
+适用场景：电厂数据安全要求不允许上传至第三方云服务。
+
+### 6.2 轻量替代：OpenTelemetry + Jaeger
+
+```python
+# 使用 opentelemetry-sdk 手工 instrument LangChain 调用
+from opentelemetry import trace
+tracer = trace.get_tracer("hydro-om-copilot")
+
+with tracer.start_as_current_span("reasoning_node") as span:
+    span.set_attribute("query", state["raw_query"])
+    result = await reasoning_node(state)
+    span.set_attribute("risk_level", result["risk_level"])
+```
+
+Jaeger UI 提供 Trace 时间线视图，数据存储在本地（Elasticsearch 或 Cassandra）。
+
+代价：需自行实现 LangChain instrumentation，不如 LangSmith 开箱即用。
+
+### 6.3 最小可行实现：结构化日志 + ELK
+
+最低成本方案：在每次诊断完成后，输出结构化 JSON 日志：
+
+```python
+import structlog
+log = structlog.get_logger()
+
+log.info(
+    "diagnosis_complete",
+    session_id=state["session_id"],
+    topic=state["topic"],
+    risk_level=state["risk_level"],
+    sources=state["sources"],
+    # 不记录 raw_query 和 image_base64（隐私保护）
+    node_durations={"symptom_parser": 1.8, "reasoning": 6.2, ...},
+)
+```
+
+通过 Filebeat → Logstash → Elasticsearch → Kibana 形成可查询的日志分析平台，满足基本审计需求。
+
+---
+
+## 7. 后续集成路径（Roadmap）
+
+### 7.1 在线 A/B 测试不同 Prompt 版本
+
+LangSmith 支持同一 Dataset 对比两套 prompt 的评估分数：
+
+```
+prompt_v1: REASONING_PROMPT（当前版本）
+prompt_v2: REASONING_PROMPT + "请优先考虑设备年龄和历次检修记录"（实验版本）
+```
+
+在 L3 台账接入后，通过 A/B 测试确认 prompt 改进带来的实际诊断质量提升。
+
+### 7.2 用户反馈写回 LangSmith
+
+前端"诊断结果"卡片底部添加 👍/👎 按钮，用户反馈通过 LangSmith feedback API 写回对应 Run：
+
+```python
+client.create_feedback(
+    run_id=run_id,
+    key="diagnosis_quality",
+    score=1,  # 1=好, 0=差
+    comment="根因判断准确，步骤清晰",
+)
+```
+
+积累足够反馈后，可将高质量 Run 导出为 Golden Dataset 用于评估。
+
+### 7.3 自动 Regression Testing
+
+每次知识库更新（`ingest_kb.py` 运行）后，触发自动评估：
+
+```bash
+# CI/CD 钩子（占位）
+python scripts/eval_retrieval.py --compare-baseline
+# 若 Top-5 Recall 下降 > 5%，标记为失败，阻止知识库部署
+```

--- a/docs/06-frontend-design-system.md
+++ b/docs/06-frontend-design-system.md
@@ -1,0 +1,204 @@
+# 前端设计系统：工业 HMI 暗色主题
+
+## 1. 设计定位
+
+**目标**：工业精密仪器美学 — 类 DCS/SCADA 控制室的现代 SaaS 品质。
+**语境**：高风险故障诊断，操作人员在高压环境下快速读取信息，视觉语言须传达「精密、可靠、专业」。
+
+与通用 SaaS 产品的关键差异：
+- 结构化参数输入（机组/设备/异常类型选择器）而非纯聊天框，体现领域专用诊断工具定位
+- 琥珀色作为工业安全语言主色（对应现实中仪表盘警示色）
+- 高信息密度布局，右侧结果面板可同时展示 5 个模块
+
+---
+
+## 2. 颜色系统（`tailwind.config.ts`）
+
+### 2.1 Surface 层级
+
+| Token | 颜色值 | 用途 |
+|-------|--------|------|
+| `surface` | `#0a0f1a` | 页面底色、`body` |
+| `surface-card` | `#0f1928` | 卡片背景（导航栏、结果卡片）|
+| `surface-elevated` | `#162032` | 次级背景（输入框、代码块、进度条背景）|
+| `surface-border` | `#1e3a5f` | 所有分隔线、边框 |
+
+层级关系：`surface < surface-card < surface-elevated`，越「高」的元素越亮。
+
+### 2.2 琥珀色 Accent
+
+| Token | 颜色值 | 用途 |
+|-------|--------|------|
+| `amber` / `amber-500` | `#f59e0b` | 主 accent：选中态、进度条、按钮 |
+| `amber-glow` / `amber-400` | `#fbbf24` | Hover 高光 |
+| `amber-dim` / `amber-800` | `#92400e` | 禁用态、低对比场景 |
+
+Glow 效果通过 CSS 变量实现（`index.css`）：
+```css
+--amber-glow: 0 0 12px rgba(245, 158, 11, 0.4);
+--amber-glow-strong: 0 0 20px rgba(245, 158, 11, 0.6);
+```
+
+### 2.3 文字层级
+
+| Token | 颜色值 | 用途 |
+|-------|--------|------|
+| `text-primary` | `#e2e8f0` | 主体文字 |
+| `text-secondary` | `#94a3b8` | 次要文字、描述 |
+| `text-muted` | `#475569` | 占位符、标签、时间戳 |
+
+### 2.4 风险等级色（本地定义，不从 store 读取）
+
+> **重要**：`diagnosisStore.ts` 导出的 `riskLevelColor` 是浅色主题 Tailwind 类，不可在深色主题中直接使用。各组件需本地定义 `darkRiskColors`。
+
+| 风险等级 | 文字色 | 背景色 | 边框色 | 特效 |
+|---------|--------|--------|--------|------|
+| `low` | `emerald-400` | `emerald-950` | `emerald-800` | — |
+| `medium` | `amber` | `amber-950` | `amber-800` | — |
+| `high` | `orange-400` | `orange-950` | `orange-800` | — |
+| `critical` | `red-400` | `red-950` | `red-800` | `critical-pulse` 动画 |
+
+---
+
+## 3. 字体系统
+
+| 变量 | 字体 | 用途 |
+|------|------|------|
+| `font-display` | Rajdhani (400/500/600/700) | 技术标签、编号、章节头、按钮文字 |
+| `font-sans` | Noto Sans SC (400/500) | 中文正文、描述、诊断内容 |
+| `font-mono` | JetBrains Mono (400/500) | 报告内容、知识库引用 ID、流式输出 |
+
+字体通过 `index.css` 顶部 Google Fonts `@import` 加载，生产环境如需离线可换为本地 font-face。
+
+**Rajdhani 用法规范**：
+- 章节标题：`font-display text-xs uppercase tracking-widest text-text-muted`
+- 卡片编号：`font-display text-lg font-bold text-amber`
+- 步骤标签：`font-display text-xs font-bold tracking-wider`
+
+---
+
+## 4. 布局结构
+
+### 4.1 顶级页面布局
+
+```
+<Nav />                     ← sticky top-0, h-[52px], bg-surface-card
+<div flex h-[calc(100vh-52px)]>
+  <aside w-5/12 sticky>     ← 输入 + 流式输出
+  <main  w-7/12 scroll>     ← 诊断结果 5 模块
+</div>
+```
+
+导航栏高度为 **52px**（`py-3` + 内容），`h-[calc(100vh-52px)]` 确保双列高度精准填满视口，两侧各自独立滚动。
+
+### 4.2 输入面板卡片
+
+```
+border-l-2 border-l-amber   ← 左侧琥珀色边框作为视觉锚点
+bg-surface-card
+```
+
+---
+
+## 5. 组件规范
+
+### 5.1 InputPanel — 结构化参数输入
+
+层级从上到下：
+1. **机组编号** — 按钮组（#1机 ~ #4机），单选可取消
+2. **设备部件** — 单选 chips（6 个部件）
+3. **异常类型** — 多选 chips（7 种异常）
+4. **建议填充栏** — 当有选中项且输入框为空时展示，点击「填入描述」写入模板文字
+5. **异常描述** — `textarea`，amber focus ring
+6. **截图上传** — 拖拽区 / 点击；有图片时显示缩略图 + 删除按钮
+7. **提交 / 停止** — 全宽 amber 按钮 / 红色停止按钮
+
+Chip 状态：
+```
+inactive: border-surface-border bg-surface-elevated text-text-secondary
+active:   border-amber bg-amber/10 text-amber
+```
+
+**关键**：`unit_id` 字段来自 `selectedUnit` state（字符串如 `"#1机"`），直接传入 `DiagnosisRequest.unit_id`；不写入 query 文本。
+
+### 5.2 StreamingOutput — 流水线可视化
+
+```
+[symptom_parser] —— [image_agent] —— [retrieval] —— [reasoning] —— [report_gen]
+```
+
+节点状态：
+- `done`：`bg-amber border-amber`（实心琥珀）
+- `active`：`bg-amber/20 border-amber node-active`（带 pulse 动画）
+- `pending`：`bg-surface-elevated border-surface-border`（空心灰）
+
+连接线：done 节点后的线段变为 `bg-amber`，未完成保持 `bg-surface-border`。
+
+流式文本区域应用 `.scan-line` CSS class（3s 扫描光效）。
+
+### 5.3 RootCauseCard — 工业卡片
+
+```
+border-l-4 border-l-amber     ← 左侧加粗边框
+[01] 标题                       ← Rajdhani 字体编号
+████████░░ 82%                  ← 块状进度条（10块，每块=10%）
+▸ 证据条目                       ← amber 箭头
+⚠ 待确认参数                     ← amber 警告框
+```
+
+概率条用字符拼接：`Array.from({length:10}, (_,i) => i < filled ? '█' : '░').join('')`
+
+### 5.4 ChecklistPanel — SOP 格式
+
+每步结构：
+```
+[自定义checkbox]  STEP 01   操作描述
+                  预期结果（可选）
+                  ⚠ CAUTION: 注意事项（红色框，可选）
+```
+
+完成后：行背景变 `emerald-950/20`，文字 `line-through opacity-50`。
+
+底部进度条：`X / Y 步骤已完成`，amber 填充。
+
+### 5.5 RiskBadge
+
+从不引用 `diagnosisStore.riskLevelColor`（浅色主题），始终使用本地 `darkRiskColors` mapping。
+
+### 5.6 ReportDraft — 正式文档
+
+顶部 header 区域：报告标题 + 日期时间 + `sessionId.slice(0,8)`
+正文：`font-mono` 等宽字体
+底部 footer：AI 生成免责声明
+复制按钮：amber → emerald 成功态
+
+---
+
+## 6. 动画规范（`index.css`）
+
+| Class | 效果 | 用途 |
+|-------|------|------|
+| `.scan-line` | 3s 琥珀扫描光 | 流式输出文本区域 |
+| `.node-active` | 节点 pulse（1.5s） | 当前执行中的流水线节点 |
+| `.critical-pulse` | 红色边框闪烁（1s） | `critical` 级别风险徽章 |
+| `.animate-result` | fade-slide-up（0.35s） | 结果模块出现动画 |
+
+**结果模块交错动画**：通过 inline `style={{ animationDelay: '...s', opacity: 0 }}` 实现，各模块延迟间隔约 50-80ms。
+
+---
+
+## 7. 历史页面
+
+- 空态：居中 ⚡ 图标（`opacity-10`）+ `font-display uppercase tracking-widest`
+- 记录卡片：`border-l-2 border-l-surface-border hover:border-l-amber`（hover 时左侧亮起）
+- 风险徽章：同 `darkRiskColors` mapping
+
+---
+
+## 8. 设计约束
+
+1. **不修改 `diagnosisStore.ts`** — `riskLevelColor` 导出保留（历史兼容），但深色主题组件不使用
+2. **不新增 npm 包** — 所有 UI 用 Tailwind + CSS variables 实现，不引入 Framer Motion 等动画库
+3. **字体 fallback** — `font-display` 定义为 `['Rajdhani', 'sans-serif']`，Google Fonts 加载失败时降级为系统 sans-serif
+4. **中文字体** — Noto Sans SC 作为 `font-sans`，确保所有中文诊断内容可读性
+5. **无障碍** — checkbox 自定义实现须保留 `aria-label`

--- a/scripts/ingest_kb.py
+++ b/scripts/ingest_kb.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Knowledge Base Ingestion Script
+================================
+Loads all Markdown documents from knowledge_base/docs_internal,
+chunks them, embeds, and stores in ChromaDB + BM25 pickle files.
+
+Usage:
+    cd hydro-om-copilot
+    uv run scripts/ingest_kb.py [--kb-dir <path>] [--reset]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running from repo root without installing the package
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+
+from app.config import settings
+from app.rag.document_loader import load_kb_documents
+from app.rag.chunker import chunk_documents
+from app.rag.vectorstore import build_vectorstore, add_documents
+from app.rag.bm25_index import BM25Index
+
+# Corpus → doc_id prefixes mapping
+CORPUS_MAP = {
+    "procedure": ["L2.TOPIC.", "L1."],
+    "rule": ["L2.SUPPORT.RULE"],
+    "case": ["L2.SUPPORT.CASE"],
+}
+
+
+def _filter_chunks(chunks, prefixes):
+    return [c for c in chunks if any(
+        (c.metadata.get("doc_id") or "").startswith(p) for p in prefixes
+    )]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Ingest knowledge base into vector store")
+    parser.add_argument("--kb-dir", default=settings.kb_docs_dir)
+    parser.add_argument("--reset", action="store_true", help="Clear existing collections first")
+    args = parser.parse_args()
+
+    kb_dir = Path(args.kb_dir)
+    if not kb_dir.exists():
+        print(f"[ERROR] KB directory not found: {kb_dir}")
+        sys.exit(1)
+
+    print(f"[1/4] Loading documents from {kb_dir} …")
+    docs = list(load_kb_documents(kb_dir))
+    print(f"      Loaded {len(docs)} documents")
+
+    print("[2/4] Chunking …")
+    chunks = chunk_documents(docs)
+    print(f"      {len(chunks)} chunks produced")
+
+    vector_store_dir = Path(settings.chroma_persist_dir)
+    vector_store_dir.mkdir(parents=True, exist_ok=True)
+
+    for corpus, prefixes in CORPUS_MAP.items():
+        corpus_chunks = _filter_chunks(chunks, prefixes)
+        print(f"[3/4] Ingesting corpus '{corpus}': {len(corpus_chunks)} chunks …")
+
+        # Dense vector store
+        vs = build_vectorstore(collection=f"hydro_kb_{corpus}")
+        if args.reset:
+            try:
+                vs.delete_collection()
+                vs = build_vectorstore(collection=f"hydro_kb_{corpus}")
+            except Exception:
+                pass
+        add_documents(vs, corpus_chunks)
+
+        # BM25 index
+        bm25 = BM25Index(corpus_chunks)
+        bm25_path = vector_store_dir / f"bm25_{corpus}.pkl"
+        bm25.save(bm25_path)
+        print(f"      BM25 index saved → {bm25_path}")
+
+    print("[4/4] Done. Knowledge base is ready for retrieval.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_kb.py
+++ b/scripts/validate_kb.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""
+Validates YAML front-matter metadata completeness across all KB documents.
+
+Usage:
+    uv run scripts/validate_kb.py
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "backend"))
+
+from app.rag.document_loader import load_kb_documents
+from app.config import settings
+
+REQUIRED_FIELDS = ["doc_id", "doc_level", "route_keys"]
+OPTIONAL_FIELDS = ["upstream", "downstream", "title"]
+
+
+def main():
+    docs = list(load_kb_documents(settings.kb_docs_dir))
+    errors = []
+    warnings = []
+
+    for doc in docs:
+        m = doc.metadata
+        source = m.get("source", "?")
+        for field in REQUIRED_FIELDS:
+            if not m.get(field):
+                errors.append(f"MISSING {field}: {source}")
+        for field in OPTIONAL_FIELDS:
+            if not m.get(field):
+                warnings.append(f"WARN missing {field}: {source}")
+
+    if warnings:
+        print("\n".join(warnings))
+    if errors:
+        print("\n".join(errors))
+        sys.exit(1)
+
+    print(f"✓ All {len(docs)} documents passed validation.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **`CLAUDE.md`** (新建) — Claude Code 和开发者快速参考手册：技术栈、完整目录结构、所有 dev/lint/build 命令、架构约束（不可修改文件清单）、`darkRiskColors` 模式说明、Agent 流程、KB 结构、代码规范、常见问题排查
- **`docs/06-frontend-design-system.md`** (新建) — 工业 HMI 暗色主题设计系统完整文档：颜色 token 表（surface/amber/text/risk）、字体系统（Rajdhani/Noto Sans SC/JetBrains Mono）、布局结构、所有组件规范（InputPanel 结构化选择器、流水线节点、SOP 检查清单等）、动画 class 规范、设计约束
- **`docs/01-tech-stack.md`** (更新) — 补充字体选型理由、ESLint v9 + typescript-eslint 条目、ruff 条目、新增第 7 节 Lint 工具链（含配置片段）
- 将之前未追踪的 `docs/02-05`、`scripts/`、`docker-compose.yml`、`.env.example` 一并纳入版本控制

## Test plan

- [ ] `CLAUDE.md` 中所有命令可在对应目录执行
- [ ] 设计系统文档中的 Tailwind 类名与 `tailwind.config.ts` 中的 token 一致
- [ ] `docs/01-tech-stack.md` lint 章节配置与 `frontend/eslint.config.js` 及 `backend/pyproject.toml` 实际内容匹配

🤖 Generated with [Claude Code](https://claude.com/claude-code)