### PR TITLE
fix: resolve code-contract sync issues (P1/P2)

### DIFF
--- a/backend/app/api/routes/diagnosis.py
+++ b/backend/app/api/routes/diagnosis.py
@@ -10,9 +10,11 @@ from fastapi.responses import StreamingResponse
 from app.api.deps import get_graph
 from app.models.request import DiagnosisRequest
 from app.models.response import CheckStep, DiagnosisResult, RiskLevel, RootCause
-from app.utils.streaming import sse_format, stream_agent_events
+from app.utils.streaming import sse_format
 
 router = APIRouter(prefix="/diagnosis", tags=["diagnosis"])
+
+_NODE_NAMES = {"symptom_parser", "image_agent", "retrieval", "reasoning", "report_gen"}
 
 
 @router.post("/run")
@@ -25,6 +27,10 @@ async def run_diagnosis(
 
     The client should use EventSource or fetch + ReadableStream to consume events.
     Event types: status | token | result | error
+
+    Single-invocation pattern: astream_events accumulates on_chain_end outputs
+    per node into `accumulated`, then builds DiagnosisResult without a second
+    graph.ainvoke call.
     """
     session_id = request.session_id or str(uuid.uuid4())
 
@@ -48,27 +54,45 @@ async def run_diagnosis(
     }
 
     async def event_generator():
-        final_state = None
+        accumulated: dict = {}
 
-        async for chunk in stream_agent_events(graph, initial_state):
-            yield chunk
-
-        # After streaming completes, emit the final structured result
-        # (LangGraph astream_events doesn't directly return final state;
-        #  we re-invoke to get final state for the result event)
         try:
-            final_state = await graph.ainvoke(initial_state)
+            async for event in graph.astream_events(initial_state, version="v2"):
+                kind = event.get("event", "")
+                name = event.get("name", "")
+
+                if kind == "on_chain_start" and name in _NODE_NAMES:
+                    yield await sse_format("status", {"node": name, "phase": "start"})
+
+                elif kind == "on_chain_end" and name in _NODE_NAMES:
+                    yield await sse_format("status", {"node": name, "phase": "end"})
+                    output = event.get("data", {}).get("output") or {}
+                    if isinstance(output, dict):
+                        accumulated.update(output)
+
+                elif kind == "on_chat_model_stream":
+                    chunk = event.get("data", {}).get("chunk")
+                    if chunk and hasattr(chunk, "content") and chunk.content:
+                        yield await sse_format("token", {"text": chunk.content})
+
+        except Exception as exc:
+            yield await sse_format("error", {"message": str(exc)})
+            return
+
+        # Build final structured result from accumulated node outputs
+        try:
+            merged = {**initial_state, **accumulated}
             result = DiagnosisResult(
                 session_id=session_id,
-                unit_id=(final_state.get("parsed_symptom") or {}).get("unit_id"),
-                topic=final_state.get("topic"),
-                root_causes=[RootCause(**rc) for rc in final_state.get("root_causes", [])],
-                check_steps=[CheckStep(**cs) for cs in final_state.get("check_steps", [])],
-                risk_level=RiskLevel(final_state.get("risk_level", "medium")),
-                escalation_required=final_state.get("escalation_required", False),
-                escalation_reason=final_state.get("escalation_reason"),
-                report_draft=final_state.get("report_draft"),
-                sources=final_state.get("sources", []),
+                unit_id=(merged.get("parsed_symptom") or {}).get("unit_id"),
+                topic=merged.get("topic"),
+                root_causes=[RootCause(**rc) for rc in merged.get("root_causes", [])],
+                check_steps=[CheckStep(**cs) for cs in merged.get("check_steps", [])],
+                risk_level=RiskLevel(merged.get("risk_level", "medium")),
+                escalation_required=merged.get("escalation_required", False),
+                escalation_reason=merged.get("escalation_reason"),
+                report_draft=merged.get("report_draft"),
+                sources=merged.get("sources", []),
             )
             yield await sse_format("result", result.model_dump())
         except Exception as exc:

--- a/backend/app/models/response.py
+++ b/backend/app/models/response.py
@@ -39,7 +39,7 @@ class DiagnosisResult(BaseModel):
     unit_id: str | None = None
     topic: str | None = Field(
         default=None,
-        description="Routed topic: vibration_swing | governor_oil | bearing_temp",
+        description="Routed topic: vibration_swing | governor_oil_pressure | bearing_temp_cooling",
     )
     root_causes: list[RootCause] = Field(default_factory=list)
     check_steps: list[CheckStep] = Field(default_factory=list)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -50,6 +50,9 @@ dev = [
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.build.targets.wheel]
+packages = ["app"]
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"

--- a/backend/tests/test_agents/test_symptom_parser.py
+++ b/backend/tests/test_agents/test_symptom_parser.py
@@ -10,9 +10,9 @@ def test_infer_topic_vibration():
 
 def test_infer_topic_governor():
     parsed = {"symptoms": ["油压低"], "device": "主配压阀"}
-    assert _infer_topic(parsed) == "governor_oil"
+    assert _infer_topic(parsed) == "governor_oil_pressure"
 
 
 def test_infer_topic_bearing():
     parsed = {"symptoms": ["温升异常"], "device": "推力轴承"}
-    assert _infer_topic(parsed) == "bearing_temp"
+    assert _infer_topic(parsed) == "bearing_temp_cooling"

--- a/docs/01-tech-stack.md
+++ b/docs/01-tech-stack.md
@@ -253,7 +253,7 @@ select = ["E", "F", "I", "UP"]
 |-----------|----------|------|--------------|
 | ChromaDB vs Qdrant | ChromaDB（dev） | 无法多进程写入 | 生产部署 / 多电厂 |
 | BM25 Pickle vs ES | Pickle 文件 | 无法增量更新，重建成本 O(n) | 文档量 > 10K / 在线更新需求 |
-| 双调用模式 | astream + ainvoke | LLM 调用额外触发一次 | P2 优化：在 astream_events 中捕获最终 state |
+| ~~双调用模式~~ (**已废弃**) | ~~astream + ainvoke~~ → 单次 astream_events + on_chain_end 累积 | 双调用：LLM 成本翻倍、延迟翻倍、结果不一致风险 | 已修复，禁止在生产路径中使用 |
 | 关键词路由 vs LLM 分类 | 关键词打分 | 不覆盖新故障类型 | 故障类型 > 10 类 / 召回率 < 80% |
 | 本地嵌入 vs API 嵌入 | 本地 BGE | 首次加载 ~2GB 模型权重 | GPU 推理加速需求 / 云端部署 |
 | SSE vs WebSocket | SSE | 单向推送，无法客户端 → 服务端流 | 需要人机交互节点（human-in-the-loop） |

--- a/frontend/src/pages/DiagnosisPage.tsx
+++ b/frontend/src/pages/DiagnosisPage.tsx
@@ -12,8 +12,8 @@ import type { DiagnosisRequest, DiagnosisResult } from "@/types/diagnosis";
 
 const TOPIC_LABELS: Record<string, string> = {
   vibration_swing: "振动与摆度",
-  governor_oil: "调速器油压",
-  bearing_temp: "轴承温升",
+  governor_oil_pressure: "调速器油压",
+  bearing_temp_cooling: "轴承温升",
 };
 
 function getSourceColor(docId: string): string {

--- a/frontend/src/types/diagnosis.ts
+++ b/frontend/src/types/diagnosis.ts
@@ -1,7 +1,7 @@
 // ── Enums ────────────────────────────────────────────────────────────────────
 
 export type RiskLevel = "low" | "medium" | "high" | "critical";
-export type DiagnosisTopic = "vibration_swing" | "governor_oil" | "bearing_temp";
+export type DiagnosisTopic = "vibration_swing" | "governor_oil_pressure" | "bearing_temp_cooling";
 
 // ── Structured output models (mirrors backend Pydantic) ──────────────────────
 


### PR DESCRIPTION
## Summary

- **[P1] SSE double-invocation removed**: `diagnosis.py` now uses a single `graph.astream_events` pass, accumulating `on_chain_end` outputs per node into `accumulated` dict; no second `graph.ainvoke` call. Eliminates doubled LLM cost/latency and result inconsistency risk.
- **[P1] Topic key alignment**: `frontend/src/types/diagnosis.ts` `DiagnosisTopic` and `DiagnosisPage.tsx` `TOPIC_LABELS` keys corrected to `governor_oil_pressure` / `bearing_temp_cooling`; `response.py` Field description updated to match.
- **[P1] Test assertions fixed**: `test_symptom_parser.py` updated from stale `governor_oil` / `bearing_temp` to canonical values.
- **[P2] Hatchling wheel config added**: `pyproject.toml` now has `[tool.hatch.build.targets.wheel] packages = ["app"]`, unblocking `uv run pytest`.
- **[P2] Docs trade-off table updated**: `docs/01-tech-stack.md` marks double-invocation as deprecated/fixed.

## Test plan

- [ ] `uv tool run ruff check backend/` → All checks passed
- [ ] `cd frontend && npm run type-check` → no errors
- [ ] `cd frontend && npm run lint` → no errors
- [ ] Backend: `uv run pytest` should resolve hatchling build error
- [ ] SSE stream: single diagnosis request triggers exactly one LangGraph execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)