### PR TITLE
fix: unit_id context loss in auto-diagnosis and shutdown task leak

### DIFF
--- a/backend/app/agents/auto_diagnosis.py
+++ b/backend/app/agents/auto_diagnosis.py
@@ -32,9 +32,17 @@ async def run_auto_diagnosis(
     session_id = f"auto-{uuid.uuid4()}"
     graph = get_compiled_graph()
 
+    # 单条语料场景下 symptom_text 不含机组号前缀，显式注入确保
+    # symptom_parser 能提取 parsed_symptom.unit_id，避免 report_gen 退化为"未知机组"
+    raw_query = (
+        summary.symptom_text
+        if summary.unit_id in summary.symptom_text
+        else f"【{summary.unit_id}】{summary.symptom_text}"
+    )
+
     initial_state = {
         "session_id": session_id,
-        "raw_query": summary.symptom_text,
+        "raw_query": raw_query,
         "image_base64": None,
         "parsed_symptom": None,
         "ocr_text": None,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ async def lifespan(app: FastAPI):
 
     # Start FaultAggregator background polling task (opt-in via AUTO_RANDOM_PROBLEMS_GEN)
     polling_task: asyncio.Task | None = None
+    _diagnosis_tasks: set[asyncio.Task] = set()
     if settings.auto_random_problems_gen:
         from app.agents.auto_diagnosis import run_auto_diagnosis
         from app.store.diagnosis_store import get_store
@@ -43,7 +44,9 @@ async def lifespan(app: FastAPI):
                 summary.fault_types,
                 summary.symptom_text[:120],
             )
-            asyncio.create_task(_run_auto_diagnosis(summary))
+            task = asyncio.create_task(_run_auto_diagnosis(summary))
+            _diagnosis_tasks.add(task)
+            task.add_done_callback(_diagnosis_tasks.discard)
 
         agg = FaultAggregator(cooldown_s=settings.diagnosis_cooldown_s)
         polling_task = asyncio.create_task(
@@ -69,6 +72,11 @@ async def lifespan(app: FastAPI):
         except asyncio.CancelledError:
             pass
         _logger.info("FaultAggregator stopped")
+
+    # Drain in-flight auto-diagnosis tasks before exit
+    if _diagnosis_tasks:
+        await asyncio.gather(*_diagnosis_tasks, return_exceptions=True)
+        _logger.info("in-flight diagnosis tasks drained | count=%d", len(_diagnosis_tasks))
 
 
 app = FastAPI(

--- a/backend/tests/test_auto_diagnosis/test_auto_diagnosis_runner.py
+++ b/backend/tests/test_auto_diagnosis/test_auto_diagnosis_runner.py
@@ -66,10 +66,36 @@ class TestRunAutoDiagnosis:
         assert record is store.list_all()[0]
 
     @pytest.mark.asyncio
-    async def test_raw_query_is_symptom_text(self):
+    async def test_raw_query_prefixed_when_unit_id_absent(self):
+        """P1 fix: unit_id 不在 symptom_text 中时自动注入前缀【unit_id】。"""
         store = DiagnosisStore(max_size=5)
-        summary = _make_summary()
+        summary = _make_summary()  # symptom_text 不含 "#1机"
+        assert summary.unit_id not in summary.symptom_text
 
+        captured_state: dict = {}
+
+        async def mock_ainvoke(state, **kwargs):
+            captured_state.update(state)
+            return _make_final_state(state["session_id"])
+
+        with patch("app.agents.auto_diagnosis.get_compiled_graph") as mock_graph_fn:
+            mock_graph_fn.return_value.ainvoke = mock_ainvoke
+            await run_auto_diagnosis(summary, store)
+
+        assert captured_state["raw_query"].startswith(f"【{summary.unit_id}】")
+        assert summary.symptom_text in captured_state["raw_query"]
+
+    @pytest.mark.asyncio
+    async def test_raw_query_unchanged_when_unit_id_present(self):
+        """P1 fix: unit_id 已在 symptom_text 中时不重复添加前缀。"""
+        store = DiagnosisStore(max_size=5)
+        summary = FaultSummary(
+            unit_id="#2机",
+            fault_types=["vibration_swing"],
+            anomaly_points=[],
+            symptom_text="【#2机】水导摆度升高至 0.52 mm，1倍转频成分显著",
+            sensor_reports=[],
+        )
         captured_state: dict = {}
 
         async def mock_ainvoke(state, **kwargs):


### PR DESCRIPTION
## Summary

- **P1 — unit_id context loss**: When `FaultAggregator` produces a single-corpus `symptom_text`, the unit_id prefix is absent. `run_auto_diagnosis()` now checks `if summary.unit_id in summary.symptom_text` and injects `【unit_id】` into `raw_query` when missing, ensuring `symptom_parser` reliably extracts `parsed_symptom.unit_id` and `report_gen` doesn't fall back to "未知机组".
- **P2 — shutdown task leak**: `asyncio` tasks spawned by `_on_fault` were fire-and-forget. `_diagnosis_tasks: set[asyncio.Task]` is now initialised in the outer lifespan scope; each task registers `add_done_callback(_diagnosis_tasks.discard)` for automatic cleanup; remaining in-flight tasks are drained with `asyncio.gather(..., return_exceptions=True)` during shutdown.

## Test plan

- [x] `test_raw_query_prefixed_when_unit_id_absent` — verifies `【unit_id】` prefix injection
- [x] `test_raw_query_unchanged_when_unit_id_present` — verifies no double-prefix
- [x] All 20 tests in `tests/test_auto_diagnosis/` pass
- [x] `ruff check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)