### PR TITLE
fix(harness): verify bundle branch ownership before skipping Claim PR mutex

### DIFF
--- a/scripts/harness.sh
+++ b/scripts/harness.sh
@@ -479,6 +479,31 @@ cmd_bugfix() {
   [[ -n "$bundle_branch" ]] && branch_req=$(echo "$bundle_branch" | grep -oE '(REQ|BUG)-[0-9]+' | head -1) || true
   [[ -n "$stacked_base"  ]] && branch_req=$(echo "$stacked_base"  | grep -oE '(REQ|BUG)-[0-9]+' | head -1) || true
 
+  # ── Bundle 所有权验证（fail closed）──────────────────────────────────────────
+  # Bundle 模式跳过 Claim PR mutex，只有在 REQ 分支已被 Agent 持有时才安全。
+  # 验证：REQ 文件 status=in_progress 且 owner≠unassigned，且分支在 origin 上存在。
+  if [[ -n "$bundle_branch" ]]; then
+    if [[ -z "$branch_req" ]]; then
+      die "--bundle 分支名 '${bundle_branch}' 无法解析出 REQ-xxx 编号，无法验证所有权\n请确认分支命名格式为 feat/REQ-xxx-... 并重试"
+    fi
+    local _req_file_b="${REPO_ROOT}/tasks/features/${branch_req}.md"
+    [[ -f "$_req_file_b" ]] \
+      || die "--bundle 目标 ${branch_req}.md 不存在，无法验证所有权\n如需 Bundle 模式，该 REQ 必须先在 tasks/features/ 中完成 Claim PR"
+    local _req_status_b _req_owner_b
+    _req_status_b=$(grep '^status:' "$_req_file_b" | awk '{print $2}' | tr -d '"')
+    _req_owner_b=$( grep '^owner:'  "$_req_file_b" | awk '{print $2}' | tr -d '"')
+    if [[ "$_req_status_b" != "in_progress" ]]; then
+      die "--bundle 目标 ${branch_req} status=${_req_status_b}（期望 in_progress）\nBundle 模式仅适用于同一 Agent 正在实现中的 REQ 分支\n请改用 Stacked PR 或在 REQ 完成后单独修复"
+    fi
+    if [[ "$_req_owner_b" == "unassigned" ]]; then
+      die "--bundle 目标 ${branch_req} owner=unassigned（期望 agent 标识）\nBundle 模式仅适用于已被 Agent 认领的 REQ 分支\n请先通过 Claim PR mutex 认领该 REQ，再使用 --bundle"
+    fi
+    if ! git ls-remote --exit-code origin "$bundle_branch" > /dev/null 2>&1; then
+      die "--bundle 分支 '${bundle_branch}' 在 origin 上不存在\n请确认分支名称正确，或先 push 该分支到 origin"
+    fi
+    info "Bundle 所有权验证通过：${branch_req} status=${_req_status_b}, owner=${_req_owner_b}"
+  fi
+
   local conflicts=""
   if ! conflicts=$(check_related_req_conflict "$bug_file" "$branch_req"); then
     # Remaining conflicts after exact-id bypass — branch doesn't cover all in-progress REQs


### PR DESCRIPTION
## Summary

Before `bugfix --bundle <branch> BUG-xxx` proceeds, the script now verifies:

1. Branch name contains a parseable `REQ-xxx` id (fail closed otherwise)
2. `tasks/features/REQ-xxx.md` exists with `status=in_progress` (not unassigned or other state)
3. `owner != unassigned` — branch has been claimed by an agent via Claim PR mutex
4. The bundle branch exists on `origin`

Each check fails with an actionable error directing the operator to use Stacked PR or standard Claim PR instead.

## Why

`--bundle` skips the Claim PR mutex on the assumption the REQ branch is already exclusively held. Without verification, anyone could point `--bundle` at an arbitrary branch and silently bypass mutual exclusion.

## Test plan

- [ ] `harness bugfix --bundle feat/REQ-999-nonexistent BUG-001` → fails with "无法解析出 REQ-xxx 编号" or "不存在"
- [ ] Bundle against a REQ with `status=test_designed` → fails with "期望 in_progress"
- [ ] Bundle against a REQ with `owner=unassigned` → fails with "期望 agent 标识"
- [ ] Bundle against a branch not on origin → fails with "在 origin 上不存在"
- [ ] Valid bundle (REQ in_progress, agent-owned, branch on origin) → proceeds normally

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)