### PR TITLE
docs: align bug-reporting templates to GitHub-first policy

### DIFF
--- a/agents/openai-codex/SOUL.md
+++ b/agents/openai-codex/SOUL.md
@@ -144,8 +144,8 @@ status: designed  # designed | implemented | passing | failing
 
 2. 默认路径 — 开 GitHub issue：
    gh issue create \
-     --title '<severity>: <简短标题>' \
-     --body '## 现象\n...\n## 预期行为\n...\n## 复现步骤\n...\n## Severity\n<P1/P2/P3>'
+     --title '[<S1|S2|S3|S4>] <简短标题>' \
+     --body '## 现象\n...\n## 预期行为\n...\n## 复现步骤\n...\n## Severity\n<S1/S2/S3/S4 per bug-standard.md §4>\n\n## Priority\n<P0/P1/P2/P3 per bug-standard.md §4>'
 
 3. 仅在以下情况才提升为 repo Bug 文件（tasks/bugs/BUG-xxx.md）：
    a) Bug 需要长期跟踪（跨多个会话、跨 Sprint）

--- a/harness/agent-cli-playbook.md
+++ b/harness/agent-cli-playbook.md
@@ -160,8 +160,8 @@ A potential bug was observed: <description of observed behavior>.
 1. Determine if this is a genuine bug (vs design-as-intended)
 2. If confirmed: open a GitHub issue (default — see bug-standard.md §事实源边界):
    gh issue create \
-     --title '<severity>: <short title>' \
-     --body $'## 现象\n<description>\n\n## 预期行为\n<expected>\n\n## 复现步骤\n<steps>\n\n## Severity\n<P1/P2/P3 per bug-standard.md §4>'
+     --title '[<S1|S2|S3|S4>] <short title>' \
+     --body $'## 现象\n<description>\n\n## 预期行为\n<expected>\n\n## 复现步骤\n<steps>\n\n## Severity\n<S1/S2/S3/S4 per bug-standard.md §4>\n\n## Priority\n<P0/P1/P2/P3 per bug-standard.md §4>'
 3. Do NOT create tasks/bugs/ files unless explicitly asked to promote to the repair queue
 4. Do not claim the fix
 "


### PR DESCRIPTION
## Summary

- **`harness/agent-cli-playbook.md` Template G**: Split into G-1 (default, GitHub issue) and G-Promote (explicit repo file promotion for long-lived tracking / agent repair queue). Updated sandbox mode from `--full-auto` to `--dangerously-bypass-approvals-and-sandbox` since `gh issue create` requires network access.
- **`agents/openai-codex/SOUL.md` Mode C**: Rewritten to match — default path is `gh issue create`, repo file only when promoting to repair queue.
- **注意事项 table**: Added separate row for G-Promote (repo file path).
- **Changelog**: v0.4 entry added; frontmatter version updated.

## Why

`bug-standard.md` §事实源边界 says GitHub is the default fact source for normal bug collaboration and repo files are only for long-term / agent-repair-queue bugs. The old Template G and Mode C were creating `tasks/bugs/` files by default, contradicting this policy.

## Test plan

- [ ] Template G-1 runs `gh issue create` (not `tasks/bugs/` file creation)
- [ ] Template G-Promote creates repo file with correct branch/PR flow
- [ ] Mode C in SOUL.md describes GitHub-first path clearly

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)