### PR TITLE
docs: add TC-design pass to agent loop (Stage 2 was missing)

### DIFF
--- a/harness/ci-standard.md
+++ b/harness/ci-standard.md
@@ -85,8 +85,11 @@ jobs:
       - uses: actions/checkout@v4
       - name: Find next claimable task
         run: python scripts/agent-loop.py
-        # 扫描 tasks/features/：status=test_designed, owner=unassigned
-        # 输出下一个可认领任务，供人工决定是否触发 Agent
+        # Pass 1：扫描 tasks/features/：status=ready, owner=unassigned, test_case_ref=[]
+        #         → 触发 openai_codex TC 设计（harness.sh tc-design）
+        # Pass 2：扫描 tasks/features/：status=test_designed, owner=unassigned
+        #         → 触发 claude_code 实现（harness.sh implement）
+        # 输出可认领任务列表，供人工决定是否触发 Agent
 ```
 
 > `scripts/agent-loop.py` 当前为 stub（仅打印可认领任务列表）。

--- a/harness/harness-index.md
+++ b/harness/harness-index.md
@@ -109,12 +109,19 @@ tasks/
 ```
 PR merged to main
     └─▶ GitHub Action: scripts/agent-loop.py  [🔲 stub]
-            └─▶ 扫描 tasks/features/：status=test_designed, owner=unassigned
-            └─▶ 调用 claude -p 认领并实现
-            └─▶ claude_code 开 Draft PR
-            └─▶ openai_codex 在 GitHub PR 上 review
-            └─▶ HITL 确认 merge → 循环
+            ├─▶ Pass 1 — TC 设计（Stage 2）
+            │       └─▶ 扫描 tasks/features/：status=ready, owner=unassigned, test_case_ref=[]
+            │       └─▶ 调用 codex exec 认领并设计 TC（harness.sh tc-design）
+            │       └─▶ openai_codex 开 TC 设计 PR → HITL 确认 merge
+            └─▶ Pass 2 — 实现（Stage 3）
+                    └─▶ 扫描 tasks/features/：status=test_designed, owner=unassigned
+                    └─▶ 调用 claude -p 认领并实现（harness.sh implement）
+                    └─▶ claude_code 开 Draft PR
+                    └─▶ openai_codex 在 GitHub PR 上 review
+                    └─▶ HITL 确认 merge → 循环
 ```
+
+> 注：两个 Pass 顺序执行；Pass 1 找到可认领 TC 设计任务时优先处理，Pass 2 独立运行不受 Pass 1 阻塞（两类任务互不依赖）。
 
 > `scripts/agent-loop.py` 当前为 stub，触发机制在 [ci-standard](ci-standard.md) 中定义后接入。
 
@@ -125,3 +132,4 @@ PR merged to main
 | 版本 | 日期 | 变更摘要 |
 |---|---|---|
 | 0.1 | 2026-03-12 | 初始版本；定义完整开发循环、阶段总览、规程索引、Agent 分工和 Git-Native 编排机制 |
+| 0.2 | 2026-03-13 | 自动化 loop 补充 Pass 1（ready→TC 设计，openai_codex）和 Pass 2（test_designed→实现，claude_code）两阶段说明，对齐 Stage 2 active 状态 |


### PR DESCRIPTION
## Summary

The automated loop docs only described the implementation pass (`status=test_designed`), skipping the `ready → test_designed` TC-design stage entirely — even though Stage 2 is marked **active** and the Claim PR protocol for Codex TC design is fully specified.

This PR adds a two-pass description to both `harness-index.md` and `ci-standard.md`:

- **Pass 1** — TC design: scans `status=ready, owner=unassigned, test_case_ref=[]` → triggers `harness.sh tc-design` (openai_codex)
- **Pass 2** — Implementation: scans `status=test_designed, owner=unassigned` → triggers `harness.sh implement` (claude_code)

Also notes that the two passes run independently (a ready REQ doesn't block a test_designed REQ from being claimed simultaneously).

## Files changed

- `harness/harness-index.md` §自动化流程 — two-pass ASCII diagram; v0.2 changelog entry
- `harness/ci-standard.md` §Git-Native Agent Loop — inline comments clarifying both passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)