### PR TITLE
bug: add BUG-003 for manual diagnosis auto-toggle conflict

### DIFF
--- a/tasks/bugs/BUG-003.md
+++ b/tasks/bugs/BUG-003.md
@@ -1,0 +1,66 @@
+---
+bug_id: BUG-003
+title: 禁止手动诊断进行中切换到自动诊断模式
+status: confirmed
+severity: S2
+priority: P1
+owner: unassigned
+related_req: [REQ-005, REQ-011]
+related_tc: []
+tc_policy: required
+tc_exempt_reason: ""
+reported_by: human
+depends_on: []
+---
+
+# 现象描述
+
+当手动诊断已经开始、SSE 尚未完成时，页面顶栏里的“自动诊断”按钮仍然可点击。
+用户此时可以切换到自动诊断模式，导致诊断页左侧输入面板和右侧结果面板一起切换到自动诊断视图。
+
+这会让“正在执行中的手动诊断”从当前页面主视图中消失，造成强烈的状态割裂：
+
+- 用户无法继续在当前界面观察手动诊断流式过程
+- 用户会误以为这次手动诊断被中断、丢失或被自动诊断覆盖
+- 手动诊断与自动诊断的互斥关系在页面顶层入口没有被统一约束
+
+# 预期行为
+
+在手动诊断未完成前，不允许切换到自动诊断模式。
+
+更具体地说：
+
+- 当手动诊断处于进行中（非 `idle/done/error`）时，顶栏“自动诊断”按钮应禁用或 no-op
+- 最好给出明确反馈，例如 tooltip / toast：`手动诊断进行中，请等待完成后再切换自动诊断`
+- 只有当本次手动诊断进入 `done`、`error` 或被用户显式停止后，才允许开启自动诊断
+
+# 复现步骤
+
+1. 打开手动诊断页面
+2. 输入故障描述并点击“开始诊断”
+3. 在 SSE 流尚未结束时，点击顶栏“自动诊断”按钮
+4. 观察页面主视图是否切换为自动诊断模式
+
+# 环境信息
+
+- 分支：main
+- 相关 commit：待修复时补充
+
+# 根因分析
+
+> 修复者填写；重点检查 `App.tsx` 顶栏全局自动诊断切换入口是否复用了 `DiagnosisPage` 内部的 `isManualRunning` 约束。当前 `AutoDiagnosisPanel` 内部按钮已支持 `isManualRunning` 禁用，但顶栏入口似乎没有同样的保护。
+
+# 修复方案
+
+> 修复者填写；建议把“手动诊断进行中时禁止切自动诊断”提升为统一的顶层互斥规则，而不是只在 `AutoDiagnosisPanel` 内部局部禁用。
+
+# 回归测试
+
+> 建议新增回归 TC：
+> - 手动诊断进行中时，顶栏“自动诊断”按钮 disabled 或点击无效
+> - 手动诊断完成 / error / abort 后，顶栏“自动诊断”按钮恢复可用
+> - 切换失败时有明确用户反馈（若本次一并实现 toast / tooltip）
+
+# Agent Notes
+
+当前代码里 `DiagnosisPage` 已经把 `isManualRunning` 传给 [AutoDiagnosisPanel](/Users/danielwong/Dev/hydro-om-copilot/frontend/src/components/auto/AutoDiagnosisPanel.tsx)，所以面板内部的“启动轮询/停止轮询”按钮是受保护的；但 [App.tsx](/Users/danielwong/Dev/hydro-om-copilot/frontend/src/App.tsx) 顶栏的全局“自动诊断”切换入口看起来还没有接入同样的互斥判断。这条 Bug 的重点是把这个约束提升到页面顶层入口，避免用户在手动诊断过程中切走主视图。


### PR DESCRIPTION
## Summary
- add repo bug doc BUG-003 for the case where manual diagnosis is still running but the top-level auto-diagnosis toggle remains clickable
- link the issue to REQ-005 and REQ-011 because it crosses the manual/auto mode boundary
- record expected behavior, repro steps, and suggested regression coverage

## Validation
- python3 scripts/check_bug_frontmatter.py --strict
- python3 scripts/check_tc_readiness.py --strict
