### PR TITLE
fix(llm): restore OPENAI_API_BASE + gpt-5.4 lost in squash merge

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -55,7 +55,8 @@ class Settings(BaseSettings):
 
     # LLM — fallback (OpenAI)
     openai_api_key: str = Field(default="", alias="OPENAI_API_KEY")
-    fallback_llm_model: str = Field(default="gpt-4.5", alias="FALLBACK_LLM_MODEL")
+    openai_api_base: str = Field(default="https://api.openai.com/v1", alias="OPENAI_API_BASE")
+    fallback_llm_model: str = Field(default="gpt-5.4", alias="FALLBACK_LLM_MODEL")
 
     # Vector store
     vector_store_type: str = "chroma"  # chroma | qdrant

--- a/backend/app/utils/anthropic_client.py
+++ b/backend/app/utils/anthropic_client.py
@@ -50,7 +50,10 @@ def get_client() -> AsyncAnthropic:
 def _get_openai_client() -> AsyncOpenAI:
     global _openai_client
     if _openai_client is None:
-        _openai_client = AsyncOpenAI(api_key=settings.openai_api_key)
+        _openai_client = AsyncOpenAI(
+            api_key=settings.openai_api_key,
+            base_url=settings.openai_api_base,
+        )
     return _openai_client
 
 

--- a/backend/app/utils/llm_factory.py
+++ b/backend/app/utils/llm_factory.py
@@ -62,6 +62,7 @@ def build_llm() -> BaseChatModel:
             model=settings.fallback_llm_model,
             temperature=settings.llm_temperature,
             api_key=settings.openai_api_key,
+            base_url=settings.openai_api_base,
         )
         return primary.with_fallbacks(
             [fallback],


### PR DESCRIPTION
## Summary

#46 的 squash merge 丢失了两个后续 commit：

- `OPENAI_API_BASE` 环境变量（`config.py` + `AsyncOpenAI(base_url=...)` + `ChatOpenAI(base_url=...)`）
- 默认 fallback 模型从 `gpt-4.5` 更新为 `gpt-5.4`

没有这两项修复，OpenAI fallback 会走 `api.openai.com` 而不是代理，导致请求超时。

## Test plan

- [ ] 重启后端，触发 Anthropic 503，确认 fallback 请求走 `OPENAI_API_BASE` 指定的代理并成功返回

🤖 Generated with [Claude Code](https://claude.com/claude-code)